### PR TITLE
fixes double import error

### DIFF
--- a/src/futures_misc/stream_merge2.rs
+++ b/src/futures_misc/stream_merge2.rs
@@ -1,5 +1,5 @@
-use futures::*;
-use futures::stream::Stream;
+use futures::{Async, Poll};
+use futures::stream::{self, Stream};
 
 pub struct StreamMerge2<S1, S2: Stream> {
     stream1: stream::Fuse<S1>,

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -114,7 +114,7 @@ struct GrpcHttpClientSessionState {
 }
 
 struct ClientInner {
-    common: LoopInnerCommon<GrpcHttpClientStream>,
+    common: ConnectionMgr<GrpcHttpClientStream>,
     to_write_tx: tokio_core::channel::Sender<ClientToWriteMessage>,
     session_state: GrpcHttpClientSessionState,
 }
@@ -135,7 +135,7 @@ impl ClientInner {
 impl HttpReadLoopInner for ClientInner {
     type LoopHttpStream = GrpcHttpClientStream;
 
-    fn common(&mut self) -> &mut LoopInnerCommon<GrpcHttpClientStream> {
+    fn common(&mut self) -> &mut ConnectionMgr<GrpcHttpClientStream> {
         &mut self.common
     }
 
@@ -146,7 +146,16 @@ impl HttpReadLoopInner for ClientInner {
             .expect("read to write");
     }
 
+    fn ack_settings(&mut self, stream_id: Option<StreamId>) {
+        self.send_frame(SettingsFrame::new_ack());
+    }
+
+    fn send_window_update(&mut self, stream_id: StreamId, increment: u32, flags: u8) {
+        self.send_frame(WindowUpdateFrame::for_stream(stream_id, increment));
+    }
+
     fn out_window_increased(&mut self, stream_id: Option<StreamId>) {
+        debug!("{} increasing out_window in Client for {:?}", self.common().peer_addr, stream_id);
         self.to_write_tx.send(ClientToWriteMessage::OutWindowIncreased(stream_id))
             .expect("read to write");
     }
@@ -316,7 +325,7 @@ impl<I : Io + Send + 'static> ClientWriteLoop<I> {
 type ClientReadLoop<I> = HttpReadLoopData<I, ClientInner>;
 
 impl HttpClientConnectionAsync {
-    fn connected<I : Io + Send + 'static>(lh: reactor::Handle, connect: HttpFutureSend<I>) -> (Self, HttpFuture<()>) {
+    fn connected<I : Io + Send + 'static>(lh: reactor::Handle, peer_addr: SocketAddr, connect: HttpFutureSend<I>) -> (Self, HttpFuture<()>) {
         let (to_write_tx, to_write_rx) = tokio_core::channel::channel(&lh).unwrap();
 
         let to_write_rx = Box::new(to_write_rx.map_err(HttpError::from));
@@ -333,7 +342,7 @@ impl HttpClientConnectionAsync {
             let (read, write) = conn.split();
 
             let inner = TaskRcMut::new(ClientInner {
-                common: LoopInnerCommon::new(HttpScheme::Http),
+                common: ConnectionMgr::new(HttpScheme::Http, peer_addr),
                 to_write_tx: to_write_tx.clone(),
                 session_state: GrpcHttpClientSessionState {
                     next_stream_id: 1,
@@ -358,7 +367,7 @@ impl HttpClientConnectionAsync {
             .map(move |c| { info!("connected to {}", addr); c })
             .map_err(|e| e.into());
 
-        HttpClientConnectionAsync::connected(lh, Box::new(connect))
+        HttpClientConnectionAsync::connected(lh, addr, Box::new(connect))
     }
 
     pub fn new_tls(lh: reactor::Handle, addr: &SocketAddr) -> (Self, HttpFuture<()>) {
@@ -376,7 +385,7 @@ impl HttpClientConnectionAsync {
 
         let tls_conn = tls_conn.map_err(HttpError::from);
 
-        HttpClientConnectionAsync::connected(lh, Box::new(tls_conn))
+        HttpClientConnectionAsync::connected(lh, addr, Box::new(tls_conn))
     }
 
     pub fn start_request(

--- a/src/http_common.rs
+++ b/src/http_common.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 
 use futures::stream::Stream;
 use futures::Future;
@@ -99,18 +100,21 @@ pub trait GrpcHttpStream {
 }
 
 
-pub struct LoopInnerCommon<S>
+/// ConnectionMgr holds Streams and the Connection they are associated with.
+pub struct ConnectionMgr<S>
     where S : GrpcHttpStream,
 {
+    pub peer_addr: SocketAddr,
     pub conn: HttpConnection,
     pub streams: HashMap<StreamId, S>,
 }
 
-impl<S> LoopInnerCommon<S>
+impl<S> ConnectionMgr<S>
     where S : GrpcHttpStream,
 {
-    pub fn new(scheme: HttpScheme) -> LoopInnerCommon<S> {
-        LoopInnerCommon {
+    pub fn new(scheme: HttpScheme, peer_addr: SocketAddr) -> ConnectionMgr<S> {
+        ConnectionMgr {
+            peer_addr: peer_addr,
             conn: HttpConnection::new(scheme),
             streams: HashMap::new(),
         }
@@ -121,6 +125,7 @@ impl<S> LoopInnerCommon<S>
     }
 
     pub fn remove_stream(&mut self, stream_id: StreamId) -> Option<S> {
+        debug!("{} removing stream {:?}", self.peer_addr, stream_id);
         self.streams.remove(&stream_id)
     }
 
@@ -135,36 +140,57 @@ impl<S> LoopInnerCommon<S>
 pub trait HttpReadLoopInner : 'static {
     type LoopHttpStream : GrpcHttpStream;
 
-    fn common(&mut self) -> &mut LoopInnerCommon<Self::LoopHttpStream>;
+    fn common(&mut self) -> &mut ConnectionMgr<Self::LoopHttpStream>;
 
     /// Send a frame back to the network
     /// Must not be data frame
     fn send_frame<R : FrameIR>(&mut self, frame: R);
     fn out_window_increased(&mut self, stream_id: Option<StreamId>);
 
+    // Sends an SETTINGS Frame with ack set to acknowledge seeing a SETTINGS frame from the peer.
+    fn ack_settings(&mut self, stream_id: Option<StreamId>);
+
+    // Sends a Window Update to peer to increase our window size by `increment`
+    fn send_window_update(&mut self, stream_id: StreamId, increment: u32, flags: u8);
+
     fn process_headers_frame(&mut self, frame: HeadersFrame);
 
     fn process_settings_global(&mut self, _frame: SettingsFrame) {
+        debug!("{} received SETTINGS {:?}", self.common().peer_addr, _frame);
         // TODO: apply settings
-        // TODO: send ack
+
+        self.ack_settings(None);
     }
 
+    // Processing WINDOW_UPDATE sent from the peer for a specific stream
     fn process_stream_window_update_frame(&mut self, frame: WindowUpdateFrame) {
         {
-            let stream = self.common().get_stream_mut(frame.get_stream_id()).expect("stream not found");
-            stream.common_mut().out_window_size.try_increase(frame.increment())
-                .expect("failed to increment stream window");
+            debug!("{}: WINDOW_UPDATE: Incrementing stream #{} by {} octets", self.common().peer_addr, frame.get_stream_id(), frame.increment());
+            match self.common().get_stream_mut(frame.get_stream_id()) {
+                Some(stream) =>  stream.common_mut()
+                    .out_window_size.try_increase(frame.increment())
+                    .expect("failed to increment stream window"),
+                None => warn!("Attempted to update window on a stream that has been closed {:?}", frame),
+            }
         }
         self.out_window_increased(Some(frame.get_stream_id()));
     }
 
+    // Processing WINDOW_UPDATE sent from the peer for the entire connection
     fn process_conn_window_update(&mut self, frame: WindowUpdateFrame) {
+        debug!("{}, WINDOW_UPDATE: increasing connection window by {} octets", self.common().peer_addr, frame.increment());
         self.common().conn.out_window_size.try_increase(frame.increment())
             .expect("failed to increment conn window");
         self.out_window_increased(None);
     }
 
     fn process_rst_stream_frame(&mut self, _frame: RstStreamFrame) {
+        debug!("{}: RST_STREAM: received {:?}", self.common().peer_addr, _frame);
+        if _frame.raw_error_code() != 0x0 {
+            info!("RST_STREAM with problematic error code: {:?}", _frame);
+        }
+        self.common().get_stream_mut(_frame.get_stream_id()).expect("cannot process RST_STREAM as stream no longer exists").close_remote();
+        self.common().remove_stream(_frame.get_stream_id());
     }
 
     fn process_data_frame(&mut self, frame: DataFrame) {
@@ -222,7 +248,7 @@ pub trait HttpReadLoopInner : 'static {
 
     fn process_ping(&mut self, frame: PingFrame) {
         if frame.is_ack() {
-
+            debug!("{}, PING ack seen", self.common().peer_addr);
         } else {
             self.send_frame(PingFrame::new_ack(frame.opaque_data()));
         }
@@ -253,7 +279,7 @@ pub trait HttpReadLoopInner : 'static {
 
     fn process_raw_frame(&mut self, raw_frame: RawFrame) {
         let frame = HttpFrameClassified::from_raw(&raw_frame).unwrap();
-        debug!("received frame: {:?}", frame);
+        debug!("{}: received frame: {:?}", self.common().peer_addr, frame);
         match frame {
             HttpFrameClassified::Conn(f) => self.process_conn_frame(f),
             HttpFrameClassified::Stream(f) => self.process_stream_frame(f),
@@ -262,12 +288,19 @@ pub trait HttpReadLoopInner : 'static {
     }
 
     fn close_remote(&mut self, stream_id: StreamId) {
-        debug!("close remote: {}", stream_id);
+        debug!("{} closing remote: {}", self.common().peer_addr, stream_id);
 
         let remove = {
-            let mut stream = self.common().get_stream_mut(stream_id).expect("stream not found");
-            stream.close_remote();
-            stream.common().state == StreamState::Closed
+            match self.common().get_stream_mut(stream_id) {
+                Some(stream) => {
+                    stream.close_remote();
+                    stream.common().state == StreamState::Closed
+                },
+                None => {
+                    debug!("attempted to close_remote on a stream that doesn't exist {}", stream_id);
+                    false
+                },
+            }
         };
         if remove {
             self.common().remove_stream(stream_id);


### PR DESCRIPTION
* Fixes double import compile error. (hence the poor name of this branch)
* Fixes issue where unexpected EOF from client results in a never-ending event loop.
* Fixes WINDOW_UPDATE for streams (not yet connections).
* Renames LoopInnerCommon to ConnectionMgr and adds the peer address for better debuggability.
* Fixes bug where SETTINGS are not acked.
