### PR TITLE
Set TCP_NODELAY on server

### DIFF
--- a/http2/src/server.rs
+++ b/http2/src/server.rs
@@ -89,6 +89,8 @@ fn run_server_event_loop<S>(
     let loop_run = listen.incoming().map_err(HttpError::from).zip(stuff).for_each(move |((socket, peer_addr), (loop_handle, service, state))| {
         info!("accepted connection from {}", peer_addr);
 
+        socket.set_nodelay(true).expect("failed to set TCP_NODELAY");
+
         let (conn, future) = HttpServerConnectionAsync::new_plain(&loop_handle, socket, service);
 
         let conn_id = {


### PR DESCRIPTION
This improves the minimum latency of responses by setting TCP_NODELAY. In a test sending small responses on a Linux 3.13 machine, the minimum latency seen was ~40ms on master, ~1ms on this branch.