### PR TITLE
Always check grpc status code and message

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,9 @@ use protobuf::ProtobufError;
 
 #[derive(Debug)]
 pub struct GrpcMessageError {
+    // TODO: utilize grpc_status
+    // pub grpc_status: u32,
+
     /// Content of `grpc-message` header
     pub grpc_message: String,
 }

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -1,3 +1,9 @@
 pub static HEADER_GRPC_STATUS: &'static str = "grpc-status";
 pub static HEADER_GRPC_MESSAGE: &'static str = "grpc-message";
 
+// gRPC status codes.
+// TODO: more status codes.
+// TODO: should we move it to another mod?
+
+/// Not an error; returned on success.
+pub const OK: u32 = 0;

--- a/src/grpc_frame.rs
+++ b/src/grpc_frame.rs
@@ -194,12 +194,14 @@ impl Stream for GrpcFrameFromHttpFramesStreamResponse {
 
                         // Check gRPC status code and message
                         // TODO: a more detailed error message.
-                        if slice_get_header(&headers, HEADER_GRPC_STATUS) != Some("0") {
-                            let message = slice_get_header(&headers, HEADER_GRPC_MESSAGE).unwrap_or("unknown error");
-                            self.error = Some(stream::once(Err(
-                                GrpcError::GrpcMessage(GrpcMessageError { grpc_message: message.to_owned() })
-                            )));
-                            continue;
+                        if let Some(code) = slice_get_header(&headers, HEADER_GRPC_STATUS) {
+                            if code != OK.to_string() {
+                                let message = slice_get_header(&headers, HEADER_GRPC_MESSAGE).unwrap_or("unknown error");
+                                self.error = Some(stream::once(Err(
+                                    GrpcError::GrpcMessage(GrpcMessageError{ grpc_message: message.to_owned() })
+                                )));
+                                continue;
+                            }
                         }
                     }
                     HttpStreamPartContent::Data(..) => {


### PR DESCRIPTION
This PR fixes an unexpected panic:  A Foo server only supports service Foo. A Bar client sends a Bar request, then the client panics in `grpc-rust/http2/src/futures_misc/stream_single.rs:36`. 
This PR always checks grpc status code and message, convert them into a `GrpcMessageError` instead of panic.

A gRPC server sends responses with a status code and message that indicates error types, but the http status code is still 200.