### PR TITLE
handle http2 client send error

### DIFF
--- a/http2/src/client_conn.rs
+++ b/http2/src/client_conn.rs
@@ -10,6 +10,7 @@ use hpack;
 
 use futures;
 use futures::Future;
+use futures::stream;
 use futures::stream::Stream;
 
 use tokio_core::net::TcpStream;
@@ -328,7 +329,7 @@ impl HttpClientConnectionAsync {
             tokio_tls::ClientContext::new()
                 .unwrap()
                 .handshake("localhost", conn)
-        });
+        }); 
 
         let tls_conn = tls_conn.map_err(HttpError::from);
 
@@ -348,11 +349,13 @@ impl HttpClientConnectionAsync {
 
         let (req_tx, req_rx) = futures::sync::mpsc::unbounded();
 
-        call_tx.send(ClientToWriteMessage::Start(StartRequestMessage {
+        if let Err(e) = call_tx.send(ClientToWriteMessage::Start(StartRequestMessage {
             headers: headers,
             body: body,
             response_handler: req_tx,
-        })).expect("send request to client");
+        })) {
+            return Box::new(stream::once(Err(HttpError::Other(format!("send request to client {:?}", e).into()))));
+        }
 
         let req_rx = req_rx.map_err(|()| HttpError::from(io::Error::new(io::ErrorKind::Other, "req")));
 


### PR DESCRIPTION
This PR fixes an unexpected panic when the remote server closed. 