### PR TITLE
Fix order of internal message buffer

### DIFF
--- a/http2/src/http_common.rs
+++ b/http2/src/http_common.rs
@@ -136,13 +136,13 @@ impl HttpStreamCommon {
         }
 
         let pop_headers =
-            if let &HttpStreamPartContent::Headers(..) = self.outgoing.front().unwrap() {
+            if let Some(&HttpStreamPartContent::Headers(..)) = self.outgoing.back() {
                 true
             } else {
                 false
             };
         if pop_headers {
-            let r = self.outgoing.pop_front().unwrap();
+            let r = self.outgoing.pop_back().unwrap();
             let last = self.outgoing_end && self.outgoing.is_empty();
             if last {
                 self.close_local();
@@ -158,7 +158,7 @@ impl HttpStreamCommon {
         }
 
         let mut data =
-            if let Some(HttpStreamPartContent::Data(data)) = self.outgoing.pop_front() {
+            if let Some(HttpStreamPartContent::Data(data)) = self.outgoing.pop_back() {
                 data
             } else {
                 unreachable!()
@@ -168,7 +168,7 @@ impl HttpStreamCommon {
 
         if data.len() as usize > max_window as usize {
             let size = self.out_window_size.size() as usize;
-            self.outgoing.push_front(HttpStreamPartContent::Data(
+            self.outgoing.push_back(HttpStreamPartContent::Data(
                 data[size..].to_vec()
             ));
             data.truncate(size);


### PR DESCRIPTION
* In case of a large streamed rpc call the connection broke at ~64kb,
because grpc tried to renew the http stream. In this case there is more
than one message in the internall buffer. The old code pushed new
message to the front of the buffer and also poped them from front. If
there is more than one message in this buffer this will result in a
invalid order.