### PR TITLE
Add a way to check if the server is still alive

### DIFF
--- a/grpc-compiler/src/codegen.rs
+++ b/grpc-compiler/src/codegen.rs
@@ -307,6 +307,16 @@ impl<'a> ServiceGen<'a> {
 
         w.write_line("");
 
+        w.impl_for_block("::std::ops::Deref", &self.sync_server_name(), |w| {
+            w.write_line(&format!("type Target = {};", &self.async_server_name()));
+            w.write_line("");
+            w.def_fn("deref(&self) -> &Self::Target", |w| {
+                w.write_line("&self.async_server");
+            })
+        });
+
+        w.write_line("");
+
         w.def_struct(&self.sync_handler_to_async_name(), |w| {
             w.field_decl("handler", &format!("::std::sync::Arc<{} + Send + Sync>", self.sync_intf_name()));
             w.field_decl("cpupool", "::futures_cpupool::CpuPool");
@@ -366,6 +376,16 @@ impl<'a> ServiceGen<'a> {
     fn write_async_server(&self, w: &mut CodeWriter) {
         w.pub_struct(&self.async_server_name(), |w| {
             w.field_decl("grpc_server", "::grpc::server::GrpcServer");
+        });
+
+        w.write_line("");
+
+        w.impl_for_block("::std::ops::Deref", &self.async_server_name(), |w| {
+            w.write_line("type Target = ::grpc::server::GrpcServer;");
+            w.write_line("");
+            w.def_fn("deref(&self) -> &Self::Target", |w| {
+                w.write_line("&self.grpc_server");
+            })
         });
 
         w.write_line("");

--- a/src/server.rs
+++ b/src/server.rs
@@ -293,6 +293,10 @@ impl GrpcServer {
     pub fn local_addr(&self) -> &SocketAddr {
         self.server.local_addr()
     }
+
+    pub fn is_alive(&self) -> bool {
+        self.server.is_alive()
+    }
 }
 
 struct GrpcHttpServerHandlerFactory {


### PR DESCRIPTION
Usecase: In case of an panic in an implemented method the whole
http-server goes down. Using this methode the user could check if the
server is still alive, and if not start a new server