### PR TITLE
Add option for a timeout while requesting a new connection

### DIFF
--- a/http2/Cargo.toml
+++ b/http2/Cargo.toml
@@ -15,6 +15,7 @@ futures         = "0.*"
 #futures-cpupool = { git = "https://github.com/alexcrichton/futures-rs" }
 futures-cpupool = "0.*"
 tokio-core      = "0.*"
+tokio-timer     = "0.1"
 #tokio-tls       = { git = "https://github.com/tokio-rs/tokio-tls/", features = ["force-openssl"] }
 #tokio-tls       = { git = "https://github.com/tokio-rs/tokio-tls/" }
 tokio-tls       = "0.*"

--- a/http2/Cargo.toml
+++ b/http2/Cargo.toml
@@ -15,7 +15,7 @@ futures         = "0.*"
 #futures-cpupool = { git = "https://github.com/alexcrichton/futures-rs" }
 futures-cpupool = "0.*"
 tokio-core      = "0.*"
-tokio-timer     = "0.1"
+tokio-timer     = "0.*"
 #tokio-tls       = { git = "https://github.com/tokio-rs/tokio-tls/", features = ["force-openssl"] }
 #tokio-tls       = { git = "https://github.com/tokio-rs/tokio-tls/" }
 tokio-tls       = "0.*"

--- a/http2/src/client_conf.rs
+++ b/http2/src/client_conf.rs
@@ -1,6 +1,9 @@
+use std::time::Duration;
+
 #[derive(Default, Debug, Clone)]
 pub struct HttpClientConf {
     /// TCP_NODELAY
     pub no_delay: Option<bool>,
     pub thread_name: Option<String>,
+    pub timeout: Option<Duration>
 }

--- a/http2/src/client_conf.rs
+++ b/http2/src/client_conf.rs
@@ -5,5 +5,5 @@ pub struct HttpClientConf {
     /// TCP_NODELAY
     pub no_delay: Option<bool>,
     pub thread_name: Option<String>,
-    pub timeout: Option<Duration>
+    pub connection_timeout: Option<Duration>
 }

--- a/http2/src/client_conn.rs
+++ b/http2/src/client_conn.rs
@@ -18,6 +18,7 @@ use futures::stream::Stream;
 use tokio_core::net::TcpStream;
 use tokio_core::io::Io;
 use tokio_core::reactor;
+use tokio_timer::Timer;
 
 use futures_misc::*;
 
@@ -304,18 +305,23 @@ impl HttpClientConnectionAsync {
         let addr = addr.clone();
 
         let no_delay = conf.no_delay.unwrap_or(true);
+        let connect = TcpStream::connect(&addr, &lh).map_err(Into::into);
+        let map_callback = move |socket: TcpStream| {
+            info!("connected to {}", addr);
 
-        let connect = TcpStream::connect(&addr, &lh)
-            .map(move |socket| {
-                info!("connected to {}", addr);
+            socket.set_nodelay(no_delay).expect("failed to set TCP_NODELAY");
 
-                socket.set_nodelay(no_delay).expect("failed to set TCP_NODELAY");
+            socket
+        };
 
-                socket
-            })
-            .map_err(|e| e.into());
+        let connect = if let Some(timeout) = conf.timeout {
+            let timer = Timer::default();
+            timer.timeout(connect, timeout).map(map_callback).boxed()
+        } else {
+            connect.map(map_callback).boxed()
+        };
 
-        HttpClientConnectionAsync::connected(lh, Box::new(connect), conf)
+        HttpClientConnectionAsync::connected(lh, connect, conf)
     }
 
     pub fn new_tls(_lh: reactor::Handle, _addr: &SocketAddr, _conf: HttpClientConf) -> (Self, HttpFuture<()>) {

--- a/http2/src/client_conn.rs
+++ b/http2/src/client_conn.rs
@@ -314,7 +314,7 @@ impl HttpClientConnectionAsync {
             socket
         };
 
-        let connect = if let Some(timeout) = conf.timeout {
+        let connect = if let Some(timeout) = conf.connection_timeout {
             let timer = Timer::default();
             timer.timeout(connect, timeout).map(map_callback).boxed()
         } else {

--- a/http2/src/lib.rs
+++ b/http2/src/lib.rs
@@ -4,6 +4,7 @@ extern crate log;
 extern crate futures;
 extern crate tokio_core;
 extern crate tokio_tls;
+extern crate tokio_timer;
 
 extern crate hpack;
 extern crate net2;

--- a/http2/src/solicit/mod.rs
+++ b/http2/src/solicit/mod.rs
@@ -377,7 +377,7 @@ pub enum HttpError {
     UnknownStreamId,
     UnableToConnect,
     MalformedResponse,
-    Timeout,
+    ConnectionTimeout,
     Other(Box<Error + Send + Sync>),
 }
 
@@ -391,7 +391,7 @@ impl From<io::Error> for HttpError {
 
 impl<F> From<TimeoutError<F>> for HttpError {
     fn from(_err: TimeoutError<F>) -> HttpError {
-        HttpError::Timeout
+        HttpError::ConnectionTimeout
     }
 }
 
@@ -412,7 +412,7 @@ impl Error for HttpError {
             HttpError::UnknownStreamId => "Attempted an operation with an unknown HTTP/2 stream ID",
             HttpError::UnableToConnect => "An error attempting to establish an HTTP/2 connection",
             HttpError::MalformedResponse => "The received response was malformed",
-            HttpError::Timeout => "Connection time out",
+            HttpError::ConnectionTimeout => "Connection time out",
             HttpError::Other(_) => "An unknown error",
         }
     }
@@ -441,7 +441,7 @@ impl PartialEq for HttpError {
             (&HttpError::UnknownStreamId, &HttpError::UnknownStreamId) => true,
             (&HttpError::UnableToConnect, &HttpError::UnableToConnect) => true,
             (&HttpError::MalformedResponse, &HttpError::MalformedResponse) => true,
-            (&HttpError::Timeout, &HttpError::Timeout) => true,
+            (&HttpError::ConnectionTimeout, &HttpError::ConnectionTimeout) => true,
             (&HttpError::Other(ref e1), &HttpError::Other(ref e2)) => {
                 e1.description() == e2.description()
             }

--- a/http2/src/solicit/mod.rs
+++ b/http2/src/solicit/mod.rs
@@ -9,6 +9,7 @@ use std::error::Error;
 use bytes::Bytes;
 
 use misc::BsDebug;
+use tokio_timer::TimeoutError;
 
 use hpack::decoder::DecoderError;
 
@@ -376,6 +377,7 @@ pub enum HttpError {
     UnknownStreamId,
     UnableToConnect,
     MalformedResponse,
+    Timeout,
     Other(Box<Error + Send + Sync>),
 }
 
@@ -384,6 +386,12 @@ pub enum HttpError {
 impl From<io::Error> for HttpError {
     fn from(err: io::Error) -> HttpError {
         HttpError::IoError(err)
+    }
+}
+
+impl<F> From<TimeoutError<F>> for HttpError {
+    fn from(_err: TimeoutError<F>) -> HttpError {
+        HttpError::Timeout
     }
 }
 
@@ -404,6 +412,7 @@ impl Error for HttpError {
             HttpError::UnknownStreamId => "Attempted an operation with an unknown HTTP/2 stream ID",
             HttpError::UnableToConnect => "An error attempting to establish an HTTP/2 connection",
             HttpError::MalformedResponse => "The received response was malformed",
+            HttpError::Timeout => "Connection time out",
             HttpError::Other(_) => "An unknown error",
         }
     }
@@ -432,6 +441,7 @@ impl PartialEq for HttpError {
             (&HttpError::UnknownStreamId, &HttpError::UnknownStreamId) => true,
             (&HttpError::UnableToConnect, &HttpError::UnableToConnect) => true,
             (&HttpError::MalformedResponse, &HttpError::MalformedResponse) => true,
+            (&HttpError::Timeout, &HttpError::Timeout) => true,
             (&HttpError::Other(ref e1), &HttpError::Other(ref e2)) => {
                 e1.description() == e2.description()
             }


### PR DESCRIPTION
On windows the client goes in a infinite loop if it could not connect to the given server. This makes it possible to configure a timeout to prevent it.