### PR TITLE
name things as AsyncXXX instead of XXXAsync

### DIFF
--- a/grpc-compiler/src/codegen.rs
+++ b/grpc-compiler/src/codegen.rs
@@ -177,7 +177,7 @@ impl<'a> ServiceGen<'a> {
 
     // name of asynchronous interface
     fn async_intf_name(&self) -> String {
-        format!("{}Async", self.sync_intf_name())
+        format!("Async{}", self.sync_intf_name())
     }
 
     fn sync_client_name(&self) -> String {

--- a/grpc-examples/src/bin/greeter_client_async.rs
+++ b/grpc-examples/src/bin/greeter_client_async.rs
@@ -13,7 +13,7 @@ use std::env;
 fn main() {
     let name = env::args().nth(1).map(|s| s.to_owned()).unwrap_or_else(|| "world".to_owned());
 
-    let client = GreeterAsyncClient::new("localhost", 50051, false, Default::default()).unwrap();
+    let client = AsyncGreeterClient::new("localhost", 50051, false, Default::default()).unwrap();
 
     let mut req = HelloRequest::new();
     req.set_name(name);

--- a/grpc-examples/src/bin/greeter_server_async.rs
+++ b/grpc-examples/src/bin/greeter_server_async.rs
@@ -14,7 +14,7 @@ use grpc_examples::helloworld::*;
 
 struct GreeterImpl;
 
-impl GreeterAsync for GreeterImpl {
+impl AsyncGreeter for GreeterImpl {
     fn SayHello(&self, req: HelloRequest) -> GrpcFutureSend<HelloReply> {
         let mut r = HelloReply::new();
         let name = if req.get_name().is_empty() { "world" } else { req.get_name() };
@@ -25,7 +25,7 @@ impl GreeterAsync for GreeterImpl {
 }
 
 fn main() {
-    let _server = GreeterAsyncServer::new("[::]:50051", Default::default(), GreeterImpl);
+    let _server = AsyncGreeterServer::new("[::]:50051", Default::default(), GreeterImpl);
 
     loop {
         thread::park();

--- a/grpc-examples/src/bin/greeter_server_multi_server.rs
+++ b/grpc-examples/src/bin/greeter_server_multi_server.rs
@@ -15,7 +15,7 @@ use grpc_examples::helloworld::*;
 
 struct GreeterImpl;
 
-impl GreeterAsync for GreeterImpl {
+impl AsyncGreeter for GreeterImpl {
     fn SayHello(&self, req: HelloRequest) -> GrpcFutureSend<HelloReply> {
         let mut r = HelloReply::new();
         let name = if req.get_name().is_empty() { "world" } else { req.get_name() };
@@ -29,8 +29,8 @@ fn main() {
     let mut conf = GrpcServerConf::default();
     conf.http.reuse_port = Some(true);
 
-    let _server1 = GreeterAsyncServer::new("[::]:50051", conf.clone(), GreeterImpl);
-    let _server2 = GreeterAsyncServer::new("[::]:50051", conf, GreeterImpl);
+    let _server1 = AsyncGreeterServer::new("[::]:50051", conf.clone(), GreeterImpl);
+    let _server2 = AsyncGreeterServer::new("[::]:50051", conf, GreeterImpl);
 
     loop {
         thread::park();

--- a/grpc-examples/src/route_guide_grpc.rs
+++ b/grpc-examples/src/route_guide_grpc.rs
@@ -31,7 +31,7 @@ pub trait RouteGuide {
     fn RouteChat(&self, p: ::grpc::iter::GrpcIterator<super::route_guide::RouteNote>) -> ::grpc::iter::GrpcIterator<super::route_guide::RouteNote>;
 }
 
-pub trait RouteGuideAsync {
+pub trait AsyncRouteGuide {
     fn GetFeature(&self, p: super::route_guide::Point) -> ::grpc::futures_grpc::GrpcFutureSend<super::route_guide::Feature>;
 
     fn ListFeatures(&self, p: super::route_guide::Rectangle) -> ::grpc::futures_grpc::GrpcStreamSend<super::route_guide::Feature>;
@@ -44,12 +44,12 @@ pub trait RouteGuideAsync {
 // sync client
 
 pub struct RouteGuideClient {
-    async_client: RouteGuideAsyncClient,
+    async_client: AsyncRouteGuideClient,
 }
 
 impl RouteGuideClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
-        RouteGuideAsyncClient::new(host, port, tls, conf).map(|c| {
+        AsyncRouteGuideClient::new(host, port, tls, conf).map(|c| {
             RouteGuideClient {
                 async_client: c,
             }
@@ -79,7 +79,7 @@ impl RouteGuide for RouteGuideClient {
 
 // async client
 
-pub struct RouteGuideAsyncClient {
+pub struct AsyncRouteGuideClient {
     grpc_client: ::grpc::client::GrpcClient,
     method_GetFeature: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::route_guide::Point, super::route_guide::Feature>>,
     method_ListFeatures: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::route_guide::Rectangle, super::route_guide::Feature>>,
@@ -87,10 +87,10 @@ pub struct RouteGuideAsyncClient {
     method_RouteChat: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::route_guide::RouteNote, super::route_guide::RouteNote>>,
 }
 
-impl RouteGuideAsyncClient {
+impl AsyncRouteGuideClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
         ::grpc::client::GrpcClient::new(host, port, tls, conf).map(|c| {
-            RouteGuideAsyncClient {
+            AsyncRouteGuideClient {
                 grpc_client: c,
                 method_GetFeature: ::std::sync::Arc::new(::grpc::method::MethodDescriptor {
                     name: "/proto.RouteGuide/GetFeature".to_string(),
@@ -121,7 +121,7 @@ impl RouteGuideAsyncClient {
     }
 }
 
-impl RouteGuideAsync for RouteGuideAsyncClient {
+impl AsyncRouteGuide for AsyncRouteGuideClient {
     fn GetFeature(&self, p: super::route_guide::Point) -> ::grpc::futures_grpc::GrpcFutureSend<super::route_guide::Feature> {
         self.grpc_client.call_unary(p, self.method_GetFeature.clone())
     }
@@ -142,7 +142,7 @@ impl RouteGuideAsync for RouteGuideAsyncClient {
 // sync server
 
 pub struct RouteGuideServer {
-    async_server: RouteGuideAsyncServer,
+    async_server: AsyncRouteGuideServer,
 }
 
 struct RouteGuideServerHandlerToAsync {
@@ -150,7 +150,7 @@ struct RouteGuideServerHandlerToAsync {
     cpupool: ::futures_cpupool::CpuPool,
 }
 
-impl RouteGuideAsync for RouteGuideServerHandlerToAsync {
+impl AsyncRouteGuide for RouteGuideServerHandlerToAsync {
     fn GetFeature(&self, p: super::route_guide::Point) -> ::grpc::futures_grpc::GrpcFutureSend<super::route_guide::Feature> {
         let h = self.handler.clone();
         ::grpc::rt::sync_to_async_unary(&self.cpupool, p, move |p| {
@@ -187,26 +187,26 @@ impl RouteGuideServer {
             handler: ::std::sync::Arc::new(h),
         };
         RouteGuideServer {
-            async_server: RouteGuideAsyncServer::new(addr, conf, h),
+            async_server: AsyncRouteGuideServer::new(addr, conf, h),
         }
     }
 }
 
 // async server
 
-pub struct RouteGuideAsyncServer {
+pub struct AsyncRouteGuideServer {
     grpc_server: ::grpc::server::GrpcServer,
 }
 
-impl RouteGuideAsyncServer {
-    pub fn new<A : ::std::net::ToSocketAddrs, H : RouteGuideAsync + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
-        let service_definition = RouteGuideAsyncServer::new_service_def(h);
-        RouteGuideAsyncServer {
+impl AsyncRouteGuideServer {
+    pub fn new<A : ::std::net::ToSocketAddrs, H : AsyncRouteGuide + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
+        let service_definition = AsyncRouteGuideServer::new_service_def(h);
+        AsyncRouteGuideServer {
             grpc_server: ::grpc::server::GrpcServer::new(addr, conf, service_definition),
         }
     }
 
-    pub fn new_service_def<H : RouteGuideAsync + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
+    pub fn new_service_def<H : AsyncRouteGuide + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
         let handler_arc = ::std::sync::Arc::new(handler);
         ::grpc::server::ServerServiceDefinition::new(
             vec![

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -42,7 +42,7 @@ fn make_string(size: usize) -> Vec<u8> {
 
 struct TestServerImpl {}
 
-impl TestServiceAsync for TestServerImpl {
+impl AsyncTestService for TestServerImpl {
     fn EmptyCall(&self, _: Empty) -> GrpcFutureSend<Empty> {
         Box::new(futures::finished(Empty::new()))
     }
@@ -124,7 +124,7 @@ impl TestServiceAsync for TestServerImpl {
 fn main() {
     drop(env_logger::init().unwrap());
 
-    let _server = TestServiceAsyncServer::new("[::]:10000", Default::default(), TestServerImpl {});
+    let _server = AsyncTestServiceServer::new("[::]:10000", Default::default(), TestServerImpl {});
 
     loop {
         thread::park();

--- a/interop/src/test_grpc.rs
+++ b/interop/src/test_grpc.rs
@@ -37,7 +37,7 @@ pub trait TestService {
     fn HalfDuplexCall(&self, p: ::grpc::iter::GrpcIterator<super::messages::StreamingOutputCallRequest>) -> ::grpc::iter::GrpcIterator<super::messages::StreamingOutputCallResponse>;
 }
 
-pub trait TestServiceAsync {
+pub trait AsyncTestService {
     fn EmptyCall(&self, p: super::empty::Empty) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty>;
 
     fn UnaryCall(&self, p: super::messages::SimpleRequest) -> ::grpc::futures_grpc::GrpcFutureSend<super::messages::SimpleResponse>;
@@ -56,12 +56,12 @@ pub trait TestServiceAsync {
 // sync client
 
 pub struct TestServiceClient {
-    async_client: TestServiceAsyncClient,
+    async_client: AsyncTestServiceClient,
 }
 
 impl TestServiceClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
-        TestServiceAsyncClient::new(host, port, tls, conf).map(|c| {
+        AsyncTestServiceClient::new(host, port, tls, conf).map(|c| {
             TestServiceClient {
                 async_client: c,
             }
@@ -104,7 +104,7 @@ impl TestService for TestServiceClient {
 
 // async client
 
-pub struct TestServiceAsyncClient {
+pub struct AsyncTestServiceClient {
     grpc_client: ::grpc::client::GrpcClient,
     method_EmptyCall: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::empty::Empty, super::empty::Empty>>,
     method_UnaryCall: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::messages::SimpleRequest, super::messages::SimpleResponse>>,
@@ -115,10 +115,10 @@ pub struct TestServiceAsyncClient {
     method_HalfDuplexCall: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::messages::StreamingOutputCallRequest, super::messages::StreamingOutputCallResponse>>,
 }
 
-impl TestServiceAsyncClient {
+impl AsyncTestServiceClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
         ::grpc::client::GrpcClient::new(host, port, tls, conf).map(|c| {
-            TestServiceAsyncClient {
+            AsyncTestServiceClient {
                 grpc_client: c,
                 method_EmptyCall: ::std::sync::Arc::new(::grpc::method::MethodDescriptor {
                     name: "/grpc.testing.TestService/EmptyCall".to_string(),
@@ -167,7 +167,7 @@ impl TestServiceAsyncClient {
     }
 }
 
-impl TestServiceAsync for TestServiceAsyncClient {
+impl AsyncTestService for AsyncTestServiceClient {
     fn EmptyCall(&self, p: super::empty::Empty) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty> {
         self.grpc_client.call_unary(p, self.method_EmptyCall.clone())
     }
@@ -200,7 +200,7 @@ impl TestServiceAsync for TestServiceAsyncClient {
 // sync server
 
 pub struct TestServiceServer {
-    async_server: TestServiceAsyncServer,
+    async_server: AsyncTestServiceServer,
 }
 
 struct TestServiceServerHandlerToAsync {
@@ -208,7 +208,7 @@ struct TestServiceServerHandlerToAsync {
     cpupool: ::futures_cpupool::CpuPool,
 }
 
-impl TestServiceAsync for TestServiceServerHandlerToAsync {
+impl AsyncTestService for TestServiceServerHandlerToAsync {
     fn EmptyCall(&self, p: super::empty::Empty) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty> {
         let h = self.handler.clone();
         ::grpc::rt::sync_to_async_unary(&self.cpupool, p, move |p| {
@@ -266,26 +266,26 @@ impl TestServiceServer {
             handler: ::std::sync::Arc::new(h),
         };
         TestServiceServer {
-            async_server: TestServiceAsyncServer::new(addr, conf, h),
+            async_server: AsyncTestServiceServer::new(addr, conf, h),
         }
     }
 }
 
 // async server
 
-pub struct TestServiceAsyncServer {
+pub struct AsyncTestServiceServer {
     grpc_server: ::grpc::server::GrpcServer,
 }
 
-impl TestServiceAsyncServer {
-    pub fn new<A : ::std::net::ToSocketAddrs, H : TestServiceAsync + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
-        let service_definition = TestServiceAsyncServer::new_service_def(h);
-        TestServiceAsyncServer {
+impl AsyncTestServiceServer {
+    pub fn new<A : ::std::net::ToSocketAddrs, H : AsyncTestService + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
+        let service_definition = AsyncTestServiceServer::new_service_def(h);
+        AsyncTestServiceServer {
             grpc_server: ::grpc::server::GrpcServer::new(addr, conf, service_definition),
         }
     }
 
-    pub fn new_service_def<H : TestServiceAsync + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
+    pub fn new_service_def<H : AsyncTestService + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
         let handler_arc = ::std::sync::Arc::new(handler);
         ::grpc::server::ServerServiceDefinition::new(
             vec![
@@ -384,19 +384,19 @@ pub trait UnimplementedService {
     fn UnimplementedCall(&self, p: super::empty::Empty) -> ::grpc::result::GrpcResult<super::empty::Empty>;
 }
 
-pub trait UnimplementedServiceAsync {
+pub trait AsyncUnimplementedService {
     fn UnimplementedCall(&self, p: super::empty::Empty) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty>;
 }
 
 // sync client
 
 pub struct UnimplementedServiceClient {
-    async_client: UnimplementedServiceAsyncClient,
+    async_client: AsyncUnimplementedServiceClient,
 }
 
 impl UnimplementedServiceClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
-        UnimplementedServiceAsyncClient::new(host, port, tls, conf).map(|c| {
+        AsyncUnimplementedServiceClient::new(host, port, tls, conf).map(|c| {
             UnimplementedServiceClient {
                 async_client: c,
             }
@@ -412,15 +412,15 @@ impl UnimplementedService for UnimplementedServiceClient {
 
 // async client
 
-pub struct UnimplementedServiceAsyncClient {
+pub struct AsyncUnimplementedServiceClient {
     grpc_client: ::grpc::client::GrpcClient,
     method_UnimplementedCall: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::empty::Empty, super::empty::Empty>>,
 }
 
-impl UnimplementedServiceAsyncClient {
+impl AsyncUnimplementedServiceClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
         ::grpc::client::GrpcClient::new(host, port, tls, conf).map(|c| {
-            UnimplementedServiceAsyncClient {
+            AsyncUnimplementedServiceClient {
                 grpc_client: c,
                 method_UnimplementedCall: ::std::sync::Arc::new(::grpc::method::MethodDescriptor {
                     name: "/grpc.testing.UnimplementedService/UnimplementedCall".to_string(),
@@ -433,7 +433,7 @@ impl UnimplementedServiceAsyncClient {
     }
 }
 
-impl UnimplementedServiceAsync for UnimplementedServiceAsyncClient {
+impl AsyncUnimplementedService for AsyncUnimplementedServiceClient {
     fn UnimplementedCall(&self, p: super::empty::Empty) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty> {
         self.grpc_client.call_unary(p, self.method_UnimplementedCall.clone())
     }
@@ -442,7 +442,7 @@ impl UnimplementedServiceAsync for UnimplementedServiceAsyncClient {
 // sync server
 
 pub struct UnimplementedServiceServer {
-    async_server: UnimplementedServiceAsyncServer,
+    async_server: AsyncUnimplementedServiceServer,
 }
 
 struct UnimplementedServiceServerHandlerToAsync {
@@ -450,7 +450,7 @@ struct UnimplementedServiceServerHandlerToAsync {
     cpupool: ::futures_cpupool::CpuPool,
 }
 
-impl UnimplementedServiceAsync for UnimplementedServiceServerHandlerToAsync {
+impl AsyncUnimplementedService for UnimplementedServiceServerHandlerToAsync {
     fn UnimplementedCall(&self, p: super::empty::Empty) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty> {
         let h = self.handler.clone();
         ::grpc::rt::sync_to_async_unary(&self.cpupool, p, move |p| {
@@ -466,26 +466,26 @@ impl UnimplementedServiceServer {
             handler: ::std::sync::Arc::new(h),
         };
         UnimplementedServiceServer {
-            async_server: UnimplementedServiceAsyncServer::new(addr, conf, h),
+            async_server: AsyncUnimplementedServiceServer::new(addr, conf, h),
         }
     }
 }
 
 // async server
 
-pub struct UnimplementedServiceAsyncServer {
+pub struct AsyncUnimplementedServiceServer {
     grpc_server: ::grpc::server::GrpcServer,
 }
 
-impl UnimplementedServiceAsyncServer {
-    pub fn new<A : ::std::net::ToSocketAddrs, H : UnimplementedServiceAsync + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
-        let service_definition = UnimplementedServiceAsyncServer::new_service_def(h);
-        UnimplementedServiceAsyncServer {
+impl AsyncUnimplementedServiceServer {
+    pub fn new<A : ::std::net::ToSocketAddrs, H : AsyncUnimplementedService + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
+        let service_definition = AsyncUnimplementedServiceServer::new_service_def(h);
+        AsyncUnimplementedServiceServer {
             grpc_server: ::grpc::server::GrpcServer::new(addr, conf, service_definition),
         }
     }
 
-    pub fn new_service_def<H : UnimplementedServiceAsync + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
+    pub fn new_service_def<H : AsyncUnimplementedService + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
         let handler_arc = ::std::sync::Arc::new(handler);
         ::grpc::server::ServerServiceDefinition::new(
             vec![
@@ -514,7 +514,7 @@ pub trait ReconnectService {
     fn Stop(&self, p: super::empty::Empty) -> ::grpc::result::GrpcResult<super::messages::ReconnectInfo>;
 }
 
-pub trait ReconnectServiceAsync {
+pub trait AsyncReconnectService {
     fn Start(&self, p: super::messages::ReconnectParams) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty>;
 
     fn Stop(&self, p: super::empty::Empty) -> ::grpc::futures_grpc::GrpcFutureSend<super::messages::ReconnectInfo>;
@@ -523,12 +523,12 @@ pub trait ReconnectServiceAsync {
 // sync client
 
 pub struct ReconnectServiceClient {
-    async_client: ReconnectServiceAsyncClient,
+    async_client: AsyncReconnectServiceClient,
 }
 
 impl ReconnectServiceClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
-        ReconnectServiceAsyncClient::new(host, port, tls, conf).map(|c| {
+        AsyncReconnectServiceClient::new(host, port, tls, conf).map(|c| {
             ReconnectServiceClient {
                 async_client: c,
             }
@@ -548,16 +548,16 @@ impl ReconnectService for ReconnectServiceClient {
 
 // async client
 
-pub struct ReconnectServiceAsyncClient {
+pub struct AsyncReconnectServiceClient {
     grpc_client: ::grpc::client::GrpcClient,
     method_Start: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::messages::ReconnectParams, super::empty::Empty>>,
     method_Stop: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::empty::Empty, super::messages::ReconnectInfo>>,
 }
 
-impl ReconnectServiceAsyncClient {
+impl AsyncReconnectServiceClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
         ::grpc::client::GrpcClient::new(host, port, tls, conf).map(|c| {
-            ReconnectServiceAsyncClient {
+            AsyncReconnectServiceClient {
                 grpc_client: c,
                 method_Start: ::std::sync::Arc::new(::grpc::method::MethodDescriptor {
                     name: "/grpc.testing.ReconnectService/Start".to_string(),
@@ -576,7 +576,7 @@ impl ReconnectServiceAsyncClient {
     }
 }
 
-impl ReconnectServiceAsync for ReconnectServiceAsyncClient {
+impl AsyncReconnectService for AsyncReconnectServiceClient {
     fn Start(&self, p: super::messages::ReconnectParams) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty> {
         self.grpc_client.call_unary(p, self.method_Start.clone())
     }
@@ -589,7 +589,7 @@ impl ReconnectServiceAsync for ReconnectServiceAsyncClient {
 // sync server
 
 pub struct ReconnectServiceServer {
-    async_server: ReconnectServiceAsyncServer,
+    async_server: AsyncReconnectServiceServer,
 }
 
 struct ReconnectServiceServerHandlerToAsync {
@@ -597,7 +597,7 @@ struct ReconnectServiceServerHandlerToAsync {
     cpupool: ::futures_cpupool::CpuPool,
 }
 
-impl ReconnectServiceAsync for ReconnectServiceServerHandlerToAsync {
+impl AsyncReconnectService for ReconnectServiceServerHandlerToAsync {
     fn Start(&self, p: super::messages::ReconnectParams) -> ::grpc::futures_grpc::GrpcFutureSend<super::empty::Empty> {
         let h = self.handler.clone();
         ::grpc::rt::sync_to_async_unary(&self.cpupool, p, move |p| {
@@ -620,26 +620,26 @@ impl ReconnectServiceServer {
             handler: ::std::sync::Arc::new(h),
         };
         ReconnectServiceServer {
-            async_server: ReconnectServiceAsyncServer::new(addr, conf, h),
+            async_server: AsyncReconnectServiceServer::new(addr, conf, h),
         }
     }
 }
 
 // async server
 
-pub struct ReconnectServiceAsyncServer {
+pub struct AsyncReconnectServiceServer {
     grpc_server: ::grpc::server::GrpcServer,
 }
 
-impl ReconnectServiceAsyncServer {
-    pub fn new<A : ::std::net::ToSocketAddrs, H : ReconnectServiceAsync + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
-        let service_definition = ReconnectServiceAsyncServer::new_service_def(h);
-        ReconnectServiceAsyncServer {
+impl AsyncReconnectServiceServer {
+    pub fn new<A : ::std::net::ToSocketAddrs, H : AsyncReconnectService + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
+        let service_definition = AsyncReconnectServiceServer::new_service_def(h);
+        AsyncReconnectServiceServer {
             grpc_server: ::grpc::server::GrpcServer::new(addr, conf, service_definition),
         }
     }
 
-    pub fn new_service_def<H : ReconnectServiceAsync + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
+    pub fn new_service_def<H : AsyncReconnectService + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
         let handler_arc = ::std::sync::Arc::new(handler);
         ::grpc::server::ServerServiceDefinition::new(
             vec![

--- a/long-tests/with-rust/src/bin/long_tests_client.rs
+++ b/long-tests/with-rust/src/bin/long_tests_client.rs
@@ -32,7 +32,7 @@ fn single_num_arg_or(cmd_args: &[String], or: u64) -> u64 {
 }
 
 
-fn run_echo(client: LongTestsAsyncClient, cmd_args: &[String]) {
+fn run_echo(client: AsyncLongTestsClient, cmd_args: &[String]) {
     let count = single_num_arg_or(cmd_args, 1);
 
     println!("running {} iterations of echo", count);
@@ -60,7 +60,7 @@ fn main() {
         panic!("too few args")
     }
 
-    let client = LongTestsAsyncClient::new("localhost", 23432, false, Default::default()).expect("init");
+    let client = AsyncLongTestsClient::new("localhost", 23432, false, Default::default()).expect("init");
 
     let cmd = &args[1];
     let cmd_args = &args[2..];

--- a/long-tests/with-rust/src/bin/long_tests_server.rs
+++ b/long-tests/with-rust/src/bin/long_tests_server.rs
@@ -21,7 +21,7 @@ use grpc::error::GrpcError;
 struct LongTestsServerImpl {
 }
 
-impl LongTestsAsync for LongTestsServerImpl {
+impl AsyncLongTests for LongTestsServerImpl {
     fn echo(&self, mut p: EchoRequest)
         -> GrpcFutureSend<EchoResponse>
     {
@@ -62,7 +62,7 @@ impl LongTestsAsync for LongTestsServerImpl {
 fn main() {
     env_logger::init().unwrap();
 
-    let _server = LongTestsAsyncServer::new(long_tests::TEST_HOST, Default::default(), LongTestsServerImpl {});
+    let _server = AsyncLongTestsServer::new(long_tests::TEST_HOST, Default::default(), LongTestsServerImpl {});
 
     loop {
         thread::park();

--- a/long-tests/with-rust/src/long_tests_pb_grpc.rs
+++ b/long-tests/with-rust/src/long_tests_pb_grpc.rs
@@ -29,7 +29,7 @@ pub trait LongTests {
     fn random_strings(&self, p: super::long_tests_pb::RandomStringsRequest) -> ::grpc::iter::GrpcIterator<super::long_tests_pb::RandomStringsResponse>;
 }
 
-pub trait LongTestsAsync {
+pub trait AsyncLongTests {
     fn echo(&self, p: super::long_tests_pb::EchoRequest) -> ::grpc::futures_grpc::GrpcFutureSend<super::long_tests_pb::EchoResponse>;
 
     fn char_count(&self, p: ::grpc::futures_grpc::GrpcStreamSend<super::long_tests_pb::CharCountRequest>) -> ::grpc::futures_grpc::GrpcFutureSend<super::long_tests_pb::CharCountResponse>;
@@ -40,12 +40,12 @@ pub trait LongTestsAsync {
 // sync client
 
 pub struct LongTestsClient {
-    async_client: LongTestsAsyncClient,
+    async_client: AsyncLongTestsClient,
 }
 
 impl LongTestsClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
-        LongTestsAsyncClient::new(host, port, tls, conf).map(|c| {
+        AsyncLongTestsClient::new(host, port, tls, conf).map(|c| {
             LongTestsClient {
                 async_client: c,
             }
@@ -70,17 +70,17 @@ impl LongTests for LongTestsClient {
 
 // async client
 
-pub struct LongTestsAsyncClient {
+pub struct AsyncLongTestsClient {
     grpc_client: ::grpc::client::GrpcClient,
     method_echo: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::long_tests_pb::EchoRequest, super::long_tests_pb::EchoResponse>>,
     method_char_count: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::long_tests_pb::CharCountRequest, super::long_tests_pb::CharCountResponse>>,
     method_random_strings: ::std::sync::Arc<::grpc::method::MethodDescriptor<super::long_tests_pb::RandomStringsRequest, super::long_tests_pb::RandomStringsResponse>>,
 }
 
-impl LongTestsAsyncClient {
+impl AsyncLongTestsClient {
     pub fn new(host: &str, port: u16, tls: bool, conf: ::grpc::client::GrpcClientConf) -> ::grpc::result::GrpcResult<Self> {
         ::grpc::client::GrpcClient::new(host, port, tls, conf).map(|c| {
-            LongTestsAsyncClient {
+            AsyncLongTestsClient {
                 grpc_client: c,
                 method_echo: ::std::sync::Arc::new(::grpc::method::MethodDescriptor {
                     name: "/LongTests/echo".to_string(),
@@ -105,7 +105,7 @@ impl LongTestsAsyncClient {
     }
 }
 
-impl LongTestsAsync for LongTestsAsyncClient {
+impl AsyncLongTests for AsyncLongTestsClient {
     fn echo(&self, p: super::long_tests_pb::EchoRequest) -> ::grpc::futures_grpc::GrpcFutureSend<super::long_tests_pb::EchoResponse> {
         self.grpc_client.call_unary(p, self.method_echo.clone())
     }
@@ -122,7 +122,7 @@ impl LongTestsAsync for LongTestsAsyncClient {
 // sync server
 
 pub struct LongTestsServer {
-    async_server: LongTestsAsyncServer,
+    async_server: AsyncLongTestsServer,
 }
 
 struct LongTestsServerHandlerToAsync {
@@ -130,7 +130,7 @@ struct LongTestsServerHandlerToAsync {
     cpupool: ::futures_cpupool::CpuPool,
 }
 
-impl LongTestsAsync for LongTestsServerHandlerToAsync {
+impl AsyncLongTests for LongTestsServerHandlerToAsync {
     fn echo(&self, p: super::long_tests_pb::EchoRequest) -> ::grpc::futures_grpc::GrpcFutureSend<super::long_tests_pb::EchoResponse> {
         let h = self.handler.clone();
         ::grpc::rt::sync_to_async_unary(&self.cpupool, p, move |p| {
@@ -160,26 +160,26 @@ impl LongTestsServer {
             handler: ::std::sync::Arc::new(h),
         };
         LongTestsServer {
-            async_server: LongTestsAsyncServer::new(addr, conf, h),
+            async_server: AsyncLongTestsServer::new(addr, conf, h),
         }
     }
 }
 
 // async server
 
-pub struct LongTestsAsyncServer {
+pub struct AsyncLongTestsServer {
     grpc_server: ::grpc::server::GrpcServer,
 }
 
-impl LongTestsAsyncServer {
-    pub fn new<A : ::std::net::ToSocketAddrs, H : LongTestsAsync + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
-        let service_definition = LongTestsAsyncServer::new_service_def(h);
-        LongTestsAsyncServer {
+impl AsyncLongTestsServer {
+    pub fn new<A : ::std::net::ToSocketAddrs, H : AsyncLongTests + 'static + Sync + Send + 'static>(addr: A, conf: ::grpc::server::GrpcServerConf, h: H) -> Self {
+        let service_definition = AsyncLongTestsServer::new_service_def(h);
+        AsyncLongTestsServer {
             grpc_server: ::grpc::server::GrpcServer::new(addr, conf, service_definition),
         }
     }
 
-    pub fn new_service_def<H : LongTestsAsync + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
+    pub fn new_service_def<H : AsyncLongTests + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::server::ServerServiceDefinition {
         let handler_arc = ::std::sync::Arc::new(handler);
         ::grpc::server::ServerServiceDefinition::new(
             vec![


### PR DESCRIPTION
Normally `Async` should be put first when appears in name, like `AsyncHTTPClient` or `AsyncTask`, rather than `HTTPAsyncClient` or `TaskAsync`.