### PR TITLE
http2: handle client stream send error

### DIFF
--- a/http2/src/client_conn.rs
+++ b/http2/src/client_conn.rs
@@ -112,8 +112,11 @@ impl LoopInner for ClientInner {
                 //               request made by the client nor any server-initiated stream (pushed)
                 return;
             }
-            Some(ref mut stream) if headers.len() != 0 => {
+            Some(stream) => {
                 // TODO: hack
+                if headers.len() == 0 {
+                    return;
+                }
                 if let Some(ref mut response_handler) = stream.response_handler {
                     response_handler.send(ResultOrEof::Item(HttpStreamPart {
                         content: HttpStreamPartContent::Headers(headers),
@@ -123,7 +126,6 @@ impl LoopInner for ClientInner {
                     Ok(())
                 }
             }
-            _ => Ok(()),
         };
 
         if let Err(e) = result {

--- a/http2/src/client_conn.rs
+++ b/http2/src/client_conn.rs
@@ -44,10 +44,13 @@ impl HttpStream for HttpClientStream {
 
     fn new_data_chunk(&mut self, data: &[u8], last: bool) {
         if let Some(ref mut response_handler) = self.response_handler {
-            response_handler.send(ResultOrEof::Item(HttpStreamPart {
+            if let Err(e) = response_handler.send(ResultOrEof::Item(HttpStreamPart {
                 content: HttpStreamPartContent::Data(Bytes::from(data)),
                 last: last,
-            })).unwrap();
+            })) {
+                // TODO: remove this stream.
+                error!("client side streaming error {:?}", e);
+            }
         }
     }
 

--- a/http2/src/http_common.rs
+++ b/http2/src/http_common.rs
@@ -242,10 +242,7 @@ impl<S> LoopInnerCommon<S>
 
     pub fn remove_stream(&mut self, stream_id: StreamId) {
         match self.streams.remove(&stream_id) {
-            Some(mut stream) => {
-                debug!("removed stream: {}", stream_id);
-                stream.closed_remote();
-            }
+            Some(_) => debug!("removed stream: {}", stream_id),
             None => debug!("incorrect request to remove stream: {}", stream_id),
         }
     }

--- a/http2/src/http_common.rs
+++ b/http2/src/http_common.rs
@@ -242,7 +242,10 @@ impl<S> LoopInnerCommon<S>
 
     pub fn remove_stream(&mut self, stream_id: StreamId) {
         match self.streams.remove(&stream_id) {
-            Some(_) => debug!("removed stream: {}", stream_id),
+            Some(mut stream) => {
+                debug!("removed stream: {}", stream_id);
+                stream.closed_remote();
+            }
             None => debug!("incorrect request to remove stream: {}", stream_id),
         }
     }


### PR DESCRIPTION
When a client stream receiver dropped, http2 client panics with an error message `SendError("...")`.
This PR removes the dropped stream and close the corresponding remote.