### PR TITLE
remove http2 from update-version.sh

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -3,7 +3,7 @@
 version="0.1.4"
 
 sed -e 's,^version = .*,version = "'$version'",' -i '' \
-    Cargo.toml http2/Cargo.toml grpc-compiler/Cargo.toml
+    Cargo.toml grpc-compiler/Cargo.toml
 
 sed -e '/httpbis.*path/ s,version = [^ ]*,version = "'$version'",' -i '' Cargo.toml
 


### PR DESCRIPTION
Http2 lib has been remove from this project, no longer needed to upgrade version with it.