### PR TITLE
Change server send mechanism to support trailing metadata

### DIFF
--- a/interop/server_test.sh
+++ b/interop/server_test.sh
@@ -2,6 +2,14 @@
 
 cd $(dirname $0)
 
+kill_server() {
+    killall -KILL grpc-rust-interop-server || true
+}
+
+../cargo.sh build
+kill_server
+../target/debug/grpc-rust-interop-server &
+
 tests=(
     empty_unary
     large_unary
@@ -15,9 +23,12 @@ tests=(
 for testname in "${tests[@]}"; do
     ./go-grpc-interop-client -use_tls=false -test_case=$testname
     if [[ $? -ne 0 ]]; then
+        kill_server
         exit -1
     fi
 done
+
+kill_server
 
 set +x
 

--- a/interop/server_test.sh
+++ b/interop/server_test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+tests=(
+    empty_unary
+    large_unary
+    ping_pong
+    empty_stream
+    custom_metadata
+    status_code_and_message
+    unimplemented_method
+)
+
+for testname in "${tests[@]}"; do
+    ./go-grpc-interop-client -use_tls=false -test_case=$testname
+    if [[ $? -ne 0 ]]; then
+        exit -1
+    fi
+done
+
+set +x
+
+echo "ALL TESTS PASSED"
+
+# vim: set ts=4 sw=4 et:

--- a/interop/src/bin/interop_server.rs
+++ b/interop/src/bin/interop_server.rs
@@ -82,10 +82,10 @@ impl TestService for TestServerImpl {
         payload.set_body(make_string(req.get_response_size() as usize));
         let mut response = SimpleResponse::new();
         response.set_payload(payload);
-        let return_value = grpc::SingleResponse::metadata_and_future(
+        let return_value = grpc::SingleResponse::metadata_and_future_and_trailing_metadata(
             echo_custom_metadata(&_o.metadata),
             future::ok(response),
-            future::ok(echo_custom_trailing(&_o.metadata)).boxed(),
+            future::ok(echo_custom_trailing(&_o.metadata)),
         );
         return return_value;
     }
@@ -142,10 +142,10 @@ impl TestService for TestServerImpl {
             }));
             ss
         }).flatten();
-        grpc::StreamingResponse::metadata_and_stream(
+        grpc::StreamingResponse::metadata_and_stream_and_trailing_metadata(
             echo_custom_metadata(&_o.metadata),
             response,
-            future::ok(echo_custom_trailing(&_o.metadata)).boxed()
+            future::ok(echo_custom_trailing(&_o.metadata))
         )
     }
 

--- a/interop/src/bin/interop_server.rs
+++ b/interop/src/bin/interop_server.rs
@@ -1,3 +1,4 @@
+extern crate bytes;
 extern crate protobuf;
 extern crate grpc;
 extern crate futures;
@@ -9,12 +10,16 @@ use grpc_interop::*;
 
 use std::thread;
 
+use bytes::Bytes;
+
 use futures::stream::Stream;
 use futures::stream;
 use futures::Future;
+use futures::future;
 
 use grpc::futures_grpc::*;
 use grpc::error::*;
+use grpc::metadata::*;
 
 static DICTIONARY: &'static str = "ABCDEFGHIJKLMNOPQRSTUVabcdefghijklmnoqprstuvwxyz0123456789";
 // Note: due to const restrictions, this is calculated by hand.
@@ -32,6 +37,30 @@ fn make_string(size: usize) -> Vec<u8> {
     }
 
     return result;
+}
+
+fn echo_custom_metadata(req_metadata: &Metadata) -> Metadata {
+    static TEST_ECHO_KEY: &'static str = "x-grpc-test-echo-initial";
+    let mut metadata = Metadata::new();
+    if let Some(value) = req_metadata.get(TEST_ECHO_KEY) {
+        metadata.add(
+            MetadataKey::from(TEST_ECHO_KEY),
+            Bytes::from(value)
+        );
+    }
+    metadata
+}
+
+fn echo_custom_trailing(req_metadata: &Metadata) -> Metadata {
+    static TEST_ECHO_TRAILING_KEY: &'static str = "x-grpc-test-echo-trailing-bin";
+    let mut metadata = Metadata::new();
+    if let Some(value) = req_metadata.get(TEST_ECHO_TRAILING_KEY) {
+        metadata.add(
+            MetadataKey::from(TEST_ECHO_TRAILING_KEY),
+            Bytes::from(value)
+        );
+    }
+    metadata
 }
 
 struct TestServerImpl {}
@@ -53,7 +82,12 @@ impl TestService for TestServerImpl {
         payload.set_body(make_string(req.get_response_size() as usize));
         let mut response = SimpleResponse::new();
         response.set_payload(payload);
-        grpc::SingleResponse::completed(response)
+        let return_value = grpc::SingleResponse::metadata_and_future(
+            echo_custom_metadata(&_o.metadata),
+            future::ok(response),
+            future::ok(echo_custom_trailing(&_o.metadata)).boxed(),
+        );
+        return return_value;
     }
 
     // TODO: is this needed? I can't find it implemented in grpc-go/interop/client/client.go
@@ -108,7 +142,11 @@ impl TestService for TestServerImpl {
             }));
             ss
         }).flatten();
-        grpc::StreamingResponse::no_metadata(response)
+        grpc::StreamingResponse::metadata_and_stream(
+            echo_custom_metadata(&_o.metadata),
+            response,
+            future::ok(echo_custom_trailing(&_o.metadata)).boxed()
+        )
     }
 
     // TODO: implement this if we find an interop client that needs it.

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -24,25 +24,28 @@ impl<T : Send + 'static> SingleResponse<T> {
         SingleResponse(Box::new(f))
     }
 
-    pub fn metadata_and_future<F>(metadata: Metadata, result: F) -> SingleResponse<T>
+    pub fn metadata_and_future<F>(metadata: Metadata, result: F, trailing: GrpcFutureSend<Metadata>) -> SingleResponse<T>
         where F : Future<Item=T, Error=error::Error> + Send + 'static
     {
-        let boxed: GrpcFutureSend<(T, Metadata)> = Box::new((result.map(|r| (r, Metadata::new()))));
+        let boxed: GrpcFutureSend<(T, Metadata)> = Box::new((result.map(|r| (
+            r,
+            trailing.wait().unwrap_or(Metadata::new())
+        ))));
         SingleResponse::new(future::ok((metadata, boxed)))
     }
 
-    pub fn completed_with_metadata(metadata: Metadata, r: T) -> SingleResponse<T> {
-        SingleResponse::metadata_and_future(metadata, future::ok(r))
+    pub fn completed_with_metadata(metadata: Metadata, r: T, trailing:Metadata) -> SingleResponse<T> {
+        SingleResponse::metadata_and_future(metadata, future::ok(r), future::ok(trailing).boxed())
     }
 
     pub fn completed(r: T) -> SingleResponse<T> {
-        SingleResponse::completed_with_metadata(Metadata::new(), r)
+        SingleResponse::completed_with_metadata(Metadata::new(), r, Metadata::new())
     }
 
     pub fn no_metadata<F>(r: F) -> SingleResponse<T>
         where F : Future<Item=T, Error=error::Error> + Send + 'static
     {
-        SingleResponse::metadata_and_future(Metadata::new(), r)
+        SingleResponse::metadata_and_future(Metadata::new(), r, future::ok(Metadata::new()).boxed())
     }
 
     pub fn err(err: error::Error) -> SingleResponse<T> {
@@ -100,37 +103,41 @@ impl<T : Send + 'static> StreamingResponse<T> {
         StreamingResponse(Box::new(f))
     }
 
-    pub fn metadata_and_stream<S>(metadata: Metadata, result: S) -> StreamingResponse<T>
+    pub fn metadata_and_stream<S>(metadata: Metadata, result: S, trailing: GrpcFutureSend<Metadata>) -> StreamingResponse<T>
         where S : Stream<Item=T, Error=error::Error> + Send + 'static
     {
-        let boxed = GrpcStreamWithTrailingMetadata::new(result.map(ItemOrMetadata::Item));
+        let boxed = GrpcStreamWithTrailingMetadata::stream_with_trailing(result, trailing);
         StreamingResponse::new(future::ok((metadata, boxed)))
     }
 
     pub fn no_metadata<S>(s: S) -> StreamingResponse<T>
         where S : Stream<Item=T, Error=error::Error> + Send + 'static
     {
-        StreamingResponse::metadata_and_stream(Metadata::new(), s)
+        StreamingResponse::metadata_and_stream(Metadata::new(), s, future::ok(Metadata::new()).boxed())
     }
 
-    pub fn completed_with_metadata(metadata: Metadata, r: Vec<T>) -> StreamingResponse<T> {
-        StreamingResponse::iter_with_metadata(metadata, r.into_iter())
+    pub fn completed_with_metadata(metadata: Metadata, r: Vec<T>, trailing: Metadata) -> StreamingResponse<T> {
+        StreamingResponse::iter_with_metadata(metadata, r.into_iter(), future::ok(trailing).boxed())
     }
 
-    pub fn iter_with_metadata<I>(metadata: Metadata, iter: I) -> StreamingResponse<T>
+    pub fn iter_with_metadata<I>(metadata: Metadata, iter: I, trailing: GrpcFutureSend<Metadata>) -> StreamingResponse<T>
         where I: Iterator<Item=T> + Send + 'static
     {
-        StreamingResponse::metadata_and_stream(metadata, stream::iter(iter.map(Ok)))
+        StreamingResponse::metadata_and_stream(
+            metadata,
+            stream::iter(iter.map(Ok)),
+            trailing
+        )
     }
 
     pub fn completed(r: Vec<T>) -> StreamingResponse<T> {
-        StreamingResponse::completed_with_metadata(Metadata::new(), r)
+        StreamingResponse::completed_with_metadata(Metadata::new(), r, Metadata::new())
     }
 
     pub fn iter<I>(iter: I) -> StreamingResponse<T>
         where I : Iterator<Item=T> + Send + 'static
     {
-        StreamingResponse::iter_with_metadata(Metadata::new(), iter)
+        StreamingResponse::iter_with_metadata(Metadata::new(), iter, future::ok(Metadata::new()).boxed())
     }
 
     pub fn empty() -> StreamingResponse<T> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,7 +25,6 @@ use futures::stream::Stream;
 
 use method::*;
 use error::*;
-//use error::Error;
 use grpc::*;
 use grpc_frame::*;
 use req::*;

--- a/src/server.rs
+++ b/src/server.rs
@@ -521,7 +521,11 @@ impl<S : CallStarter> httpbis::Service for GrpcHttpService<S> {
                 })
                 .map_err(httpbis::Error::from);
 
-            let http_parts = HttpPartStream::new(s2);
+            let s3 = stream::once(Ok(HttpStreamPart::last_headers(Headers(vec![
+                Header::new(HEADER_GRPC_STATUS, "0"),
+            ]))));
+
+            let http_parts = HttpPartStream::new(s2.chain(s3));
 
             (init_headers, http_parts)
         }))

--- a/src/stream_item.rs
+++ b/src/stream_item.rs
@@ -42,6 +42,18 @@ impl<T : Send + 'static> GrpcStreamWithTrailingMetadata<T> {
         GrpcStreamWithTrailingMetadata::new(stream.map(ItemOrMetadata::Item))
     }
 
+    /// Stream of items with no trailing metadata
+    pub fn stream_with_trailing<S>(stream: S, trailing: GrpcFutureSend<Metadata>) -> GrpcStreamWithTrailingMetadata<T>
+        where S : Stream<Item=T, Error=Error> + Send + 'static
+    {
+        let stream = GrpcStreamWithTrailingMetadata::new(stream.map(ItemOrMetadata::Item));
+        GrpcStreamWithTrailingMetadata::new(stream.0.chain(stream::once(
+            Ok(ItemOrMetadata::TrailingMetadata(
+                trailing.wait().unwrap_or(Metadata::new())
+            ))
+        )))
+    }
+
     /// Single element stream with no trailing metadata
     pub fn once(item: T) -> GrpcStreamWithTrailingMetadata<T> {
         GrpcStreamWithTrailingMetadata::stream(stream::once(Ok(item)))
@@ -115,6 +127,47 @@ impl<T : Send + 'static> GrpcStreamWithTrailingMetadata<T> {
                 }
             }))
         })
+    }
+
+    /// Apply `then` operation to items, preserving trailing metadata
+    pub fn then_items<F>(self, mut f: F) -> GrpcStreamWithTrailingMetadata<T>
+        where
+            T : Send + 'static,
+            F : FnMut(Result<T, Error>) -> Result<T, Error> + Send + 'static,
+    {
+        GrpcStreamWithTrailingMetadata::new(self.0.then( move |result| {
+            match result {
+                Ok(item) => {
+                    match item {
+                        ItemOrMetadata::Item(i) => match f(Ok(i)) {
+                            Ok(returned_item) => Ok(ItemOrMetadata::Item(returned_item)),
+                            Err(e) => Err(e)
+                        },
+                        ItemOrMetadata::TrailingMetadata(m) => Ok(ItemOrMetadata::TrailingMetadata(m)),
+                    }
+                },
+                Err(t) => match f(Err(t)) {
+                    Ok(returned_item) => Ok(ItemOrMetadata::Item(returned_item)),
+                    Err(e) => Err(e)
+                },
+            }
+        }))
+    }
+
+    /// transform Items and trailing metadata into the same type
+    pub fn normalize_metadata<U, F, H>(self, mut f: F, mut h: H) -> GrpcStreamSend<U>
+        where
+            U : Send + 'static,
+            F : FnMut(T) -> U + Send + 'static,
+            H : FnMut(Metadata) -> U + Send + 'static,
+    {
+        self.0.map(move |stream| {
+            match stream {
+                ItemOrMetadata::Item(item) => f(item),
+                ItemOrMetadata::TrailingMetadata(trailing) => h(trailing),
+            }
+        })
+        .boxed()
     }
 
     /// Return raw futures `Stream` without trailing metadata

--- a/src/stream_item.rs
+++ b/src/stream_item.rs
@@ -43,8 +43,10 @@ impl<T : Send + 'static> GrpcStreamWithTrailingMetadata<T> {
     }
 
     /// Stream of items with no trailing metadata
-    pub fn stream_with_trailing<S>(stream: S, trailing: GrpcFutureSend<Metadata>) -> GrpcStreamWithTrailingMetadata<T>
-        where S : Stream<Item=T, Error=Error> + Send + 'static
+    pub fn stream_with_trailing<S, F>(stream: S, trailing: F) -> GrpcStreamWithTrailingMetadata<T>
+        where
+            S : Stream<Item=T, Error=Error> + Send + 'static,
+            F : Future<Item=Metadata, Error=Error> + Send + 'static
     {
         let stream = GrpcStreamWithTrailingMetadata::new(stream.map(ItemOrMetadata::Item));
         GrpcStreamWithTrailingMetadata::new(stream.0.chain(stream::once(


### PR DESCRIPTION
Fixes #43 on the server side.

note: also changes the server api slightly, by adding parameters for trailing metadata