### PR TITLE
Allow multiple grpc clients through one connection

### DIFF
--- a/grpc-examples/src/bin/greeter_client_multi.rs
+++ b/grpc-examples/src/bin/greeter_client_multi.rs
@@ -1,0 +1,29 @@
+extern crate grpc_examples;
+extern crate grpc;
+extern crate futures;
+
+use grpc::Client;
+
+use grpc_examples::helloworld_grpc::*;
+use grpc_examples::helloworld::*;
+
+use std::env;
+
+
+fn main() {
+    let name = env::args().nth(1).map(|s| s.to_owned()).unwrap_or_else(|| "world".to_owned());
+
+    let client = Client::new_plain("localhost", 50051, Default::default()).unwrap();
+    let greeter_client = GreeterClient::with_client(client.clone());
+    let greeter_client2 = GreeterClient::with_client(client);
+
+    let mut req = HelloRequest::new();
+    req.set_name(name);
+    let req2 = req.clone();
+
+    let resp = greeter_client.say_hello(grpc::RequestOptions::new(), req);
+    let resp2 = greeter_client2.say_hello(grpc::RequestOptions::new(), req2);
+
+    println!("{:?}", resp.wait());
+    println!("{:?}", resp2.wait());
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -39,7 +39,7 @@ pub struct ClientConf {
 /// gRPC client implementation.
 /// Used by generated code.
 pub struct Client {
-    client: httpbis::Client,
+    client: ::std::sync::Arc<httpbis::Client>,
     host: String,
     http_scheme: HttpScheme,
 }
@@ -56,12 +56,23 @@ impl Client {
         httpbis::Client::new_plain(host, port, conf.http)
             .map(|client| {
                 Client {
-                    client: client,
+                    client: ::std::sync::Arc::new(client),
                     host: host.to_owned(),
                     http_scheme: HttpScheme::Http,
                 }
             })
             .map_err(Error::from)
+    }
+
+    /// Create a clone of this client but refer to same httpbis::Client.
+    pub fn clone(&self)
+        -> Client
+    {
+        Client {
+            client: self.client.clone(),
+            host: self.host.to_owned(),
+            http_scheme: HttpScheme::Http,
+        }
     }
 
     /// Create a client connected to specified host and port.
@@ -75,7 +86,7 @@ impl Client {
         httpbis::Client::new_tls::<C>(host, port, conf.http)
             .map(|client| {
                 Client {
-                    client: client,
+                    client: ::std::sync::Arc::new(client),
                     host: host.to_owned(),
                     http_scheme: HttpScheme::Https,
                 }
@@ -95,7 +106,7 @@ impl Client {
         httpbis::Client::new_expl(addr, tls, conf.http)
             .map(|client| {
                 Client {
-                    client: client,
+                    client: ::std::sync::Arc::new(client),
                     host: host.to_owned(),
                     http_scheme: http_scheme,
                 }


### PR DESCRIPTION
Make grpc client hold a smart pointer reference to the http client

Fixes #76