### PR TITLE
Make GrpcHttpService public

### DIFF
--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -58,6 +58,7 @@ pub use client::ClientConf;
 pub use server::Server;
 pub use server::ServerBuilder;
 pub use server::ServerConf;
+pub use server::GrpcHttpService;
 
 pub use resp::SingleResponse;
 pub use resp::StreamingResponse;

--- a/grpc/src/server.rs
+++ b/grpc/src/server.rs
@@ -131,8 +131,15 @@ impl Server {
 }
 
 /// Implementation of gRPC over http2 HttpService
-struct GrpcHttpService {
+#[derive(Clone)]
+pub struct GrpcHttpService {
     service_definition: Arc<ServerServiceDefinition>,
+}
+
+impl GrpcHttpService {
+    pub fn new(service_definition: ServerServiceDefinition) -> Self {
+        GrpcHttpService { service_definition: Arc::new(service_definition) }
+    }
 }
 
 


### PR DESCRIPTION
Makes it possible to use external event loop and server, like this:

```
struct GrpcService {};
let s = GrpcService;
let def = WhateverServiceServer::new_service_def(s);
let grpc = Arc::new(GrpcHttpService::new(def));

.. setup listener ...

listener.incoming().for_each(|(sock, addr)|) {
  let conf = httpbis::server_conf::ServerConf::new();
  let (conn, future) = httpbis::server_conn::ServerConnection::new_plain_single_threaded(&handle, sock, conf, grpc.clone());
  handle.spawn(future.map_err(|e| error!("{}", e)));
}
```