### PR TITLE
Support Unix domain sockets

### DIFF
--- a/grpc-compiler/src/codegen.rs
+++ b/grpc-compiler/src/codegen.rs
@@ -239,7 +239,16 @@ impl<'a> ServiceGen<'a> {
                 });
                 w.write_line("})");
             });
-            
+
+            let sig = "new_plain_unix(addr: &str, conf: ::grpc::ClientConf) -> ::grpc::Result<Self>";
+            w.pub_fn(sig, |w| {
+                w.write_line("::grpc::Client::new_plain_unix(addr, conf).map(|c| {");
+                w.indented(|w| {
+                    w.write_line(&format!("{}::with_client(c)", self.client_name()));
+                });
+                w.write_line("})");
+            });
+
             let sig = "new_tls<C : ::tls_api::TlsConnector>(host: &str, port: u16, conf: ::grpc::ClientConf) -> ::grpc::Result<Self>";
             w.pub_fn(sig, |w| {
                 w.write_line("::grpc::Client::new_tls::<C>(host, port, conf).map(|c| {");

--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -70,6 +70,26 @@ impl Client {
             .map_err(Error::from)
     }
 
+    /// Create a client connected to specified Unix domain socket.
+    #[cfg(unix)]
+    pub fn new_plain_unix(addr: &str, conf: ClientConf)
+        -> result::Result<Client>
+    {
+        let mut conf = conf;
+        conf.http.thread_name =
+            Some(conf.http.thread_name.unwrap_or_else(|| "grpc-client-loop".to_owned()));
+
+        httpbis::Client::new_plain_unix(addr, conf.http)
+            .map(|client| {
+                Client {
+                    client: ::std::sync::Arc::new(client),
+                    host: addr.to_owned(),
+                    http_scheme: HttpScheme::Http,
+                }
+            })
+            .map_err(Error::from)
+    }
+
     /// Create a clone of this client but refer to same httpbis::Client.
     pub fn clone(&self)
         -> Client

--- a/grpc/src/server.rs
+++ b/grpc/src/server.rs
@@ -1,6 +1,4 @@
 use std::sync::Arc;
-use std::net::SocketAddr;
-use std::net::ToSocketAddrs;
 
 use futures_cpupool::CpuPool;
 
@@ -11,6 +9,7 @@ use httpbis::Header;
 use httpbis::Headers;
 use httpbis::HttpPartStream;
 use httpbis::stream_part::HttpStreamPart;
+use httpbis::socket::AnySocketAddr;
 
 use stream_item::ItemOrMetadata;
 
@@ -99,6 +98,14 @@ impl<A : tls_api::TlsAcceptor> ServerBuilder<A> {
         }
     }
 
+    #[cfg(unix)]
+    pub fn new_unix() -> ServerBuilder<A> {
+        ServerBuilder {
+            http: httpbis::ServerBuilder::new(),
+            conf: ServerConf::new(),
+        }
+    }
+
     pub fn add_service(&mut self, def: ServerServiceDefinition) {
         self.http.service.set_service(&def.prefix.clone(), Arc::new(GrpcHttpService {
             service_definition: Arc::new(def),
@@ -121,7 +128,7 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn local_addr(&self) -> &SocketAddr {
+    pub fn local_addr(&self) -> &AnySocketAddr {
         self.server.local_addr()
     }
 

--- a/grpc/tests/client.rs
+++ b/grpc/tests/client.rs
@@ -25,3 +25,18 @@ fn server_is_not_running() {
         assert!(result.is_err(), result);
     }
 }
+
+#[cfg(unix)]
+#[test]
+fn server_is_not_running_unix() {
+    let client = Client::new_plain_unix("/tmp/grpc_rust_test", Default::default()).unwrap();
+
+    // TODO: https://github.com/tokio-rs/tokio-core/issues/12
+    if false {
+        let result = client.call_unary(
+            RequestOptions::new(),
+            "aa".to_owned(),
+            string_string_method("/does/not/matter", GrpcStreaming::Unary)).wait();
+        assert!(result.is_err(), result);
+    }
+}

--- a/grpc/tests/server.rs
+++ b/grpc/tests/server.rs
@@ -43,7 +43,7 @@ fn multiple_services() {
 
     let server = server.build().expect("server");
 
-    let client = Client::new_plain("::1", server.local_addr().port(), ClientConf::new())
+    let client = Client::new_plain("::1", server.local_addr().port().unwrap(), ClientConf::new())
         .expect("client");
 
     assert_eq!(
@@ -55,4 +55,43 @@ fn multiple_services() {
         "zyx".to_owned(),
         client.call_unary(
             RequestOptions::new(), "xyz".to_owned(), reverse).wait_drop_metadata().unwrap());
+}
+
+#[cfg(unix)]
+#[test]
+fn single_service_unix() {
+    let test_socket_address = "/tmp/grpc_rust_single_service_unix";
+    let mut server = ServerBuilder::new_plain();
+    server.http.set_unix_addr(test_socket_address.to_owned()).unwrap();
+
+    let echo = string_string_method("/foo/echo", GrpcStreaming::Unary);
+    let reverse = string_string_method("/bar/reverse", GrpcStreaming::Unary);
+
+    server.add_service(ServerServiceDefinition::new("/foo", vec![
+        ServerMethod::new(
+            echo.clone(),
+            MethodHandlerUnary::new(echo_fn))
+    ]));
+
+    server.add_service(ServerServiceDefinition::new("/bar", vec![
+        ServerMethod::new(
+            reverse.clone(),
+            MethodHandlerUnary::new(reverse_fn))
+    ]));
+
+    let _server = server.build().expect("server");
+
+    let client = Client::new_plain_unix(test_socket_address, ClientConf::new())
+        .expect("client");
+
+    assert_eq!(
+        "abc".to_owned(),
+        client.call_unary(
+            RequestOptions::new(), "abc".to_owned(), echo).wait_drop_metadata().unwrap());
+
+    assert_eq!(
+        "zyx".to_owned(),
+        client.call_unary(
+            RequestOptions::new(), "xyz".to_owned(), reverse).wait_drop_metadata().unwrap());
+
 }

--- a/grpc/tests/simple.rs
+++ b/grpc/tests/simple.rs
@@ -72,7 +72,7 @@ impl TesterUnary {
         where H : Fn(RequestOptions, String) -> SingleResponse<String> + Sync + Send + 'static
     {
         let server = new_server_unary("/text", "/Unary", handler);
-        let port = server.local_addr().port();
+        let port = server.local_addr().port().unwrap();
         TesterUnary {
             name: "/text/Unary".to_owned(),
             _server: server,
@@ -122,7 +122,7 @@ impl TesterServerStreaming {
         where H : Fn(RequestOptions, String) -> StreamingResponse<String> + Sync + Send + 'static
     {
         let server = new_server_server_streaming("/test", "/ServerStreaming", handler);
-        let port = server.local_addr().port();
+        let port = server.local_addr().port().unwrap();
         TesterServerStreaming {
             name: "/test/ServerStreaming".to_owned(),
             _server: server,
@@ -150,7 +150,7 @@ impl TesterClientStreaming {
         where H : Fn(RequestOptions, StreamingRequest<String>) -> SingleResponse<String> + Sync + Send + 'static
     {
         let server = new_server_client_streaming("/test", "/ClientStreaming", handler);
-        let port = server.local_addr().port();
+        let port = server.local_addr().port().unwrap();
         TesterClientStreaming {
             name: "/test/ClientStreaming".to_owned(),
             _server: server,


### PR DESCRIPTION
Add options to client and serverbuilder for generating servers/clients
which use Unix domain sockets.

Addresses #91