### PR TITLE
Pin futures related deps to `0.1.*`.

### DIFF
--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["grpc"]
 [dependencies]
 log             = "0.4"
 protobuf        = { version = "1.*", features = ["with-bytes"] }
-futures         = "0.1"
-futures-cpupool = "0.1"
-tokio-core      = "0.1"
-tokio-io        = "0.1"
-tokio-tls-api   = "0.1"
+futures         = "0.1.*"
+futures-cpupool = "0.1.*"
+tokio-core      = "0.1.*"
+tokio-io        = "0.1.*"
+tokio-tls-api   = "0.1.*"
 httpbis         = "=0.5.0"
 tls-api         = "0.1"
 tls-api-stub    = "0.1"


### PR DESCRIPTION
I've used this update, along with my updates in [rust-http2](https://github.com/stepancheg/rust-http2/pull/25) & [rust-tls-api](https://github.com/stepancheg/rust-tls-api/pull/19), integrated them into my create, and things appear to be back in order.