### PR TITLE
Add missing dependency for grpc-compiler on protobuf-codegen

### DIFF
--- a/grpc-compiler/Cargo.toml
+++ b/grpc-compiler/Cargo.toml
@@ -6,7 +6,8 @@ license = "MIT/Apache-2.0"
 authors = ["Stepan Koltsov <stepan.koltsov@gmail.com>"]
 
 [dependencies]
-protobuf = "1.*"
+protobuf = "1.6.0"
+protobuf-codegen = "1.6.0"
 
 [[bin]]
 

--- a/grpc-compiler/src/codegen.rs
+++ b/grpc-compiler/src/codegen.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use protobuf;
 use protobuf::compiler_plugin;
-use protobuf::code_writer::CodeWriter;
 use protobuf::descriptor::*;
 use protobuf::descriptorx::*;
+use protobuf_codegen::code_writer::CodeWriter;
 
 
 /// Adjust method name to follow the rust's style.

--- a/grpc-compiler/src/lib.rs
+++ b/grpc-compiler/src/lib.rs
@@ -1,3 +1,4 @@
 extern crate protobuf;
+extern crate protobuf_codegen;
 
 pub mod codegen;


### PR DESCRIPTION
This fixes build error when it uses latest protobuf 1.6.0.

I'm not fully sure if this is the best / right solution. But thought I would file a PR still for it as latest published crate is not building. See issue #118 