### PR TITLE
Support Unix domain sockets (port of 544aafa1078ec5bccf51e2dbb5553736771ede8d to latest)

### DIFF
--- a/grpc-compiler/src/codegen.rs
+++ b/grpc-compiler/src/codegen.rs
@@ -239,7 +239,16 @@ impl<'a> ServiceGen<'a> {
                 });
                 w.write_line("})");
             });
-            
+
+            let sig = "new_plain_unix(addr: &str, conf: ::grpc::ClientConf) -> ::grpc::Result<Self>";
+            w.pub_fn(sig, |w| {
+                w.write_line("::grpc::Client::new_plain_unix(addr, conf).map(|c| {");
+                w.indented(|w| {
+                    w.write_line(&format!("{}::with_client(c)", self.client_name()));
+                });
+                w.write_line("})");
+            });
+
             let sig = "new_tls<C : ::tls_api::TlsConnector>(host: &str, port: u16, conf: ::grpc::ClientConf) -> ::grpc::Result<Self>";
             w.pub_fn(sig, |w| {
                 w.write_line("::grpc::Client::new_tls::<C>(host, port, conf).map(|c| {");

--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -68,6 +68,26 @@ impl Client {
             .map_err(Error::from)
     }
 
+    /// Create a client connected to specified Unix domain socket.
+    #[cfg(unix)]
+    pub fn new_plain_unix(addr: &str, conf: ClientConf)
+        -> result::Result<Client>
+    {
+        let mut conf = conf;
+        conf.http.thread_name =
+            Some(conf.http.thread_name.unwrap_or_else(|| "grpc-client-loop".to_owned()));
+
+        httpbis::Client::new_plain_unix(addr, conf.http)
+            .map(|client| {
+                Client {
+                    client: ::std::sync::Arc::new(client),
+                    host: addr.to_owned(),
+                    http_scheme: HttpScheme::Http,
+                }
+            })
+            .map_err(Error::from)
+    }
+
     /// Create a clone of this client but refer to same httpbis::Client.
     pub fn clone(&self)
         -> Client

--- a/grpc/src/server.rs
+++ b/grpc/src/server.rs
@@ -96,6 +96,14 @@ impl<A : tls_api::TlsAcceptor> ServerBuilder<A> {
         }
     }
 
+    #[cfg(unix)]
+    pub fn new_unix() -> ServerBuilder<A> {
+        ServerBuilder {
+            http: httpbis::ServerBuilder::new(),
+            conf: ServerConf::new(),
+        }
+    }
+
     pub fn add_service(&mut self, def: ServerServiceDefinition) {
         self.http.service.set_service(&def.prefix.clone(), Arc::new(GrpcHttpService {
             service_definition: Arc::new(def),

--- a/grpc/tests/client.rs
+++ b/grpc/tests/client.rs
@@ -25,3 +25,18 @@ fn server_is_not_running() {
         assert!(result.is_err(), result);
     }
 }
+
+#[cfg(unix)]
+#[test]
+fn server_is_not_running_unix() {
+    let client = Client::new_plain_unix("/tmp/grpc_rust_test", Default::default()).unwrap();
+
+    // TODO: https://github.com/tokio-rs/tokio-core/issues/12
+    if false {
+        let result = client.call_unary(
+            RequestOptions::new(),
+            "aa".to_owned(),
+            string_string_method("/does/not/matter", GrpcStreaming::Unary)).wait();
+        assert!(result.is_err(), result);
+    }
+}

--- a/grpc/tests/server.rs
+++ b/grpc/tests/server.rs
@@ -61,3 +61,42 @@ fn multiple_services() {
         client.call_unary(
             RequestOptions::new(), "xyz".to_owned(), reverse).wait_drop_metadata().unwrap());
 }
+
+#[cfg(unix)]
+#[test]
+fn single_service_unix() {
+    let test_socket_address = "/tmp/grpc_rust_single_service_unix";
+    let mut server = ServerBuilder::new_plain();
+    server.http.set_unix_addr(test_socket_address.to_owned()).unwrap();
+
+    let echo = string_string_method("/foo/echo", GrpcStreaming::Unary);
+    let reverse = string_string_method("/bar/reverse", GrpcStreaming::Unary);
+
+    server.add_service(ServerServiceDefinition::new("/foo", vec![
+        ServerMethod::new(
+            echo.clone(),
+            MethodHandlerUnary::new(echo_fn))
+    ]));
+
+    server.add_service(ServerServiceDefinition::new("/bar", vec![
+        ServerMethod::new(
+            reverse.clone(),
+            MethodHandlerUnary::new(reverse_fn))
+    ]));
+
+    let _server = server.build().expect("server");
+
+    let client = Client::new_plain_unix(test_socket_address, ClientConf::new())
+        .expect("client");
+
+    assert_eq!(
+        "abc".to_owned(),
+        client.call_unary(
+            RequestOptions::new(), "abc".to_owned(), echo).wait_drop_metadata().unwrap());
+
+    assert_eq!(
+        "zyx".to_owned(),
+        client.call_unary(
+            RequestOptions::new(), "xyz".to_owned(), reverse).wait_drop_metadata().unwrap());
+
+}


### PR DESCRIPTION
From 544aafa1078ec5bccf51e2dbb5553736771ede8d
From: Bryan Blanchard <bryan.blanchard@gmail.com> 
Date: Wed, 2 Aug 2017 07:46:58 -0400 
Subject: [PATCH] Support Unix domain sockets  Add options to client and serverbuilder for generating servers/clients which use Unix domain sockets.  

Addresses #91 
