### PR TITLE
Ensure that we don't attempt to 'new_plain_unix' on non-unix

### DIFF
--- a/grpc/src/client_stub.rs
+++ b/grpc/src/client_stub.rs
@@ -37,7 +37,13 @@ impl<C: ClientStub> ClientStubExt for C {
         Client::new_tls::<T>(host, port, conf).map(|c| Self::with_client(Arc::new(c)))
     }
 
+    #[cfg(unix)]
     fn new_plain_unix(addr: &str, conf: ClientConf) -> grpc_Result<Self> {
         Client::new_plain_unix(addr, conf).map(|c| Self::with_client(Arc::new(c)))
+    }
+
+    #[cfg(not(unix))]
+    fn new_plain_unix(addr: &str, conf: ClientConf) -> grpc_Result<Self> {
+        Err(::Error::Other("new_plain_unix unsupported"))
     }
 }


### PR DESCRIPTION
Doesn't build on `x86_64-pc-windows-gnu` without this