### PR TITLE
Dereference the Arc before calling methods on the interface

### DIFF
--- a/grpc-compiler/src/codegen.rs
+++ b/grpc-compiler/src/codegen.rs
@@ -315,7 +315,7 @@ impl<'a> ServiceGen<'a> {
                             method.write_descriptor(w, "::std::sync::Arc::new(", "),");
                             w.block("{", "},", |w| {
                                 w.write_line(&format!("let handler_copy = {}.clone();", handler));
-                                w.write_line(&format!("::grpc::rt::MethodHandler{}::new(move |o, p| handler_copy.{}(o, p))",
+                                w.write_line(&format!("::grpc::rt::MethodHandler{}::new(move |o, p| (*handler_copy).{}(o, p))",
                                     method.streaming_upper(),
                                     method.snake_name()));
                             });


### PR DESCRIPTION
When calling methods on `Arc<MyService>` where the method is also defined on Arc (e.g. `drop` and `clone`), calling handler_copy.method(o, p) will actually attempt to call the Arc method instead of the method on the service, resulting in a compiler error. This change removes the ambiguity by dereferencing the `Arc`.

```proto
// proto file:
message DropReq {}
message DropResp {}
service HelloService {
    rpc Drop (DropReq) returns (DropResp);
    rpc Clone (DropReq) returns (DropResp);
}
```

```rust
// Generated _grpc.rs file:
// server
impl HelloServiceServer {
    pub fn new_service_def<H : HelloService + 'static + Sync + Send + 'static>(handler: H) -> ::grpc::rt::ServerServiceDefinition {
        …
                        ::grpc::rt::MethodHandlerUnary::new(move |o, p| handler_copy.drop(o, p))
        // compiler error: explicit destructor calls not allowed
        // compiler error: expected 0 parameters
        // compiler error: expected struct `grpc::resp::SingleResponse`, found ()
    }
}
```

An alternative fix would be to use the [fully qualified syntax for method calls](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name) (https://github.com/yonran/grpc-rust/commit/d5d7f4cd9b5ae029d7305e98209510c6bc24c151). I believe that this change should be good enough because H is only known to be `H : HelloService + 'static + Sync + Send + 'static`, and `Sync` and `Send` define no other methods.