### PR TITLE
Add a way to bring your own tokio event loop

### DIFF
--- a/grpc-examples/greeter/src/bin/greeter_client.rs
+++ b/grpc-examples/greeter/src/bin/greeter_client.rs
@@ -57,9 +57,12 @@ fn main() {
         // TODO: simplify it
         let mut tls_option =
             httpbis::ClientTlsOption::Tls("foobar.com".to_owned(), Arc::new(test_tls_connector()));
-        let addr = SocketAddr::new("::1".parse().unwrap(), port);
-        let grpc_client =
-            Arc::new(grpc::Client::new_expl(&addr, "foobar.com", tls_option, client_conf).unwrap());
+        let grpc_client = Arc::new(
+            grpc::ClientBuilder::new("::1", port)
+                .explicit_tls(tls_option)
+                .build()
+                .unwrap(),
+        );
         GreeterClient::with_client(grpc_client)
     } else {
         GreeterClient::new_plain("::1", port, client_conf).unwrap()

--- a/grpc-examples/greeter/src/bin/greeter_client_multi.rs
+++ b/grpc-examples/greeter/src/bin/greeter_client_multi.rs
@@ -2,7 +2,7 @@ extern crate futures;
 extern crate grpc;
 extern crate grpc_examples_greeter;
 
-use grpc::Client;
+use grpc::ClientBuilder;
 use grpc::ClientStub;
 
 use grpc_examples_greeter::helloworld::*;
@@ -17,7 +17,7 @@ fn main() {
         .map(|s| s.to_owned())
         .unwrap_or_else(|| "world".to_owned());
 
-    let client = Arc::new(Client::new_plain("::1", 50051, Default::default()).unwrap());
+    let client = Arc::new(ClientBuilder::new("::1", 50051).build().unwrap());
     let greeter_client = GreeterClient::with_client(client.clone());
     let greeter_client2 = GreeterClient::with_client(client);
 

--- a/grpc/src/client_stub.rs
+++ b/grpc/src/client_stub.rs
@@ -1,4 +1,4 @@
-use client::Client;
+use client::{Client, ClientBuilder};
 use std::sync::Arc;
 use ClientConf;
 use Result as grpc_Result;
@@ -26,7 +26,10 @@ pub trait ClientStubExt: Sized {
 
 impl<C: ClientStub> ClientStubExt for C {
     fn new_plain(host: &str, port: u16, conf: ClientConf) -> grpc_Result<Self> {
-        Client::new_plain(host, port, conf).map(|c| Self::with_client(Arc::new(c)))
+        ClientBuilder::new(host, port)
+            .conf(conf)
+            .build()
+            .map(|c| Self::with_client(Arc::new(c)))
     }
 
     fn new_tls<T: ::tls_api::TlsConnector>(
@@ -34,12 +37,19 @@ impl<C: ClientStub> ClientStubExt for C {
         port: u16,
         conf: ClientConf,
     ) -> grpc_Result<Self> {
-        Client::new_tls::<T>(host, port, conf).map(|c| Self::with_client(Arc::new(c)))
+        ClientBuilder::new(host, port)
+            .tls::<T>()
+            .conf(conf)
+            .build()
+            .map(|c| Self::with_client(Arc::new(c)))
     }
 
     #[cfg(unix)]
     fn new_plain_unix(addr: &str, conf: ClientConf) -> grpc_Result<Self> {
-        Client::new_plain_unix(addr, conf).map(|c| Self::with_client(Arc::new(c)))
+        ClientBuilder::new_unix(addr)
+            .conf(conf)
+            .build()
+            .map(|c| Self::with_client(Arc::new(c)))
     }
 
     #[cfg(not(unix))]

--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -51,6 +51,7 @@ pub use stream_item::ItemOrMetadata;
 
 pub use client::req_sink::ClientRequestSink;
 pub use client::Client;
+pub use client::ClientBuilder;
 pub use client::ClientConf;
 
 pub use client_stub::ClientStub;

--- a/grpc/tests/client.rs
+++ b/grpc/tests/client.rs
@@ -16,7 +16,7 @@ use test_misc::*;
 fn server_is_not_running() {
     init_logger();
 
-    let client = Client::new_plain(BIND_HOST, 2, Default::default()).unwrap();
+    let client = ClientBuilder::new(BIND_HOST, 2).build().unwrap();
 
     // TODO: https://github.com/tokio-rs/tokio-core/issues/12
     if false {
@@ -34,8 +34,9 @@ fn server_is_not_running() {
 #[test]
 fn server_is_not_running_unix() {
     init_logger();
-
-    let client = Client::new_plain_unix("/tmp/grpc_rust_test", Default::default()).unwrap();
+    let client = ClientBuilder::new_unix("/tmp/grpc_rust_test")
+        .build()
+        .unwrap();
 
     // TODO: https://github.com/tokio-rs/tokio-core/issues/12
     if false {

--- a/grpc/tests/server.rs
+++ b/grpc/tests/server.rs
@@ -50,7 +50,7 @@ fn multiple_services() {
 
     let port = server.local_addr().port().expect("port");
 
-    let client = Client::new_plain(BIND_HOST, port, ClientConf::new()).expect("client");
+    let client = ClientBuilder::new(BIND_HOST, port).build().expect("client");
 
     assert_eq!(
         "abc".to_owned(),
@@ -102,7 +102,9 @@ fn single_service_unix() {
 
     let _server = server.build().expect("server");
 
-    let client = Client::new_plain_unix(test_socket_address, ClientConf::new()).expect("client");
+    let client = ClientBuilder::new_unix(test_socket_address)
+        .build()
+        .expect("client");
 
     assert_eq!(
         "abc".to_owned(),

--- a/grpc/tests/simple.rs
+++ b/grpc/tests/simple.rs
@@ -83,7 +83,7 @@ impl TesterUnary {
         TesterUnary {
             name: "/text/Unary".to_owned(),
             _server: server,
-            client: Client::new_plain(BIND_HOST, port, Default::default()).unwrap(),
+            client: ClientBuilder::new(BIND_HOST, port).build().unwrap(),
         }
     }
 
@@ -138,7 +138,7 @@ impl TesterServerStreaming {
         TesterServerStreaming {
             name: "/test/ServerStreaming".to_owned(),
             _server: server,
-            client: Client::new_plain(BIND_HOST, port, Default::default()).unwrap(),
+            client: ClientBuilder::new(BIND_HOST, port).build().unwrap(),
         }
     }
 
@@ -171,7 +171,7 @@ impl TesterClientStreaming {
         TesterClientStreaming {
             name: "/test/ClientStreaming".to_owned(),
             _server: server,
-            client: Client::new_plain(BIND_HOST, port, Default::default()).unwrap(),
+            client: ClientBuilder::new(BIND_HOST, port).build().unwrap(),
         }
     }
 


### PR DESCRIPTION
Sometimes it is required to reuse the underlying event loop in a other context. httpbis seems to support that. This PR only exposes that through the `grpc::Client` constructors.