### PR TITLE
Added explicit "dyn" to trait objects.

### DIFF
--- a/grpc/src/client/http_request_to_grpc_frames_typed.rs
+++ b/grpc/src/client/http_request_to_grpc_frames_typed.rs
@@ -7,7 +7,7 @@ use or_static::arc::ArcOrStatic;
 
 pub(crate) fn http_req_to_grpc_frames_typed<Req: Send + 'static>(
     http_req: httpbis::ClientRequest,
-    req_marshaller: ArcOrStatic<Marshaller<Req>>,
+    req_marshaller: ArcOrStatic<dyn Marshaller<Req>>,
 ) -> ClientRequestSink<Req> {
     ClientRequestSink {
         common: SinkCommon {

--- a/grpc/src/client/http_response_to_grpc_frames_typed.rs
+++ b/grpc/src/client/http_response_to_grpc_frames_typed.rs
@@ -5,7 +5,7 @@ use or_static::arc::ArcOrStatic;
 
 pub(crate) fn http_response_to_grpc_frames_typed<Resp: Send>(
     resp: httpbis::Response,
-    marshaller: ArcOrStatic<Marshaller<Resp>>,
+    marshaller: ArcOrStatic<dyn Marshaller<Resp>>,
 ) -> StreamingResponse<Resp> {
     http_response_to_grpc_frames(resp).and_then_items(move |message| marshaller.read(message))
 }

--- a/grpc/src/client/mod.rs
+++ b/grpc/src/client/mod.rs
@@ -172,7 +172,7 @@ impl Client {
         req: Option<Req>,
         method: ArcOrStatic<MethodDescriptor<Req, Resp>>,
     ) -> Box<
-        Future<Item = (ClientRequestSink<Req>, StreamingResponse<Resp>), Error = error::Error>
+        dyn Future<Item = (ClientRequestSink<Req>, StreamingResponse<Resp>), Error = error::Error>
             + Send,
     >
     where

--- a/grpc/src/common/sink.rs
+++ b/grpc/src/common/sink.rs
@@ -42,7 +42,7 @@ impl<T: Types> SinkCommonUntyped<T> {
 }
 
 pub(crate) struct SinkCommon<M: 'static, T: Types> {
-    pub marshaller: ArcOrStatic<Marshaller<M>>,
+    pub marshaller: ArcOrStatic<dyn Marshaller<M>>,
     pub sink: T::SinkUntyped,
 }
 

--- a/grpc/src/futures_grpc.rs
+++ b/grpc/src/futures_grpc.rs
@@ -3,5 +3,5 @@ use futures::Stream;
 
 use error::Error;
 
-pub type GrpcFuture<T> = Box<Future<Item = T, Error = Error> + Send + 'static>;
-pub type GrpcStream<T> = Box<Stream<Item = T, Error = Error> + Send + 'static>;
+pub type GrpcFuture<T> = Box<dyn Future<Item = T, Error = Error> + Send + 'static>;
+pub type GrpcStream<T> = Box<dyn Stream<Item = T, Error = Error> + Send + 'static>;

--- a/grpc/src/iter.rs
+++ b/grpc/src/iter.rs
@@ -1,5 +1,5 @@
 use result;
 
-type BoxIterator<T> = Box<Iterator<Item = T> + Send>;
+type BoxIterator<T> = Box<dyn Iterator<Item = T> + Send>;
 
 pub type GrpcIterator<T> = BoxIterator<result::Result<T>>;

--- a/grpc/src/method.rs
+++ b/grpc/src/method.rs
@@ -23,6 +23,6 @@ pub struct GrpcStreamingBidi;
 pub struct MethodDescriptor<Req: 'static, Resp: 'static> {
     pub name: StringOrStatic,
     pub streaming: GrpcStreaming,
-    pub req_marshaller: ArcOrStatic<Marshaller<Req>>,
-    pub resp_marshaller: ArcOrStatic<Marshaller<Resp>>,
+    pub req_marshaller: ArcOrStatic<dyn Marshaller<Req>>,
+    pub resp_marshaller: ArcOrStatic<dyn Marshaller<Resp>>,
 }

--- a/grpc/src/misc.rs
+++ b/grpc/src/misc.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-pub fn _any_to_string(any: Box<Any + Send + 'static>) -> String {
+pub fn _any_to_string(any: Box<dyn Any + Send + 'static>) -> String {
     if any.is::<String>() {
         *any.downcast::<String>().unwrap()
     } else if any.is::<&str>() {

--- a/grpc/src/server/method.rs
+++ b/grpc/src/server/method.rs
@@ -324,7 +324,7 @@ pub(crate) trait MethodHandlerDispatchUntyped {
 
 struct MethodHandlerDispatchImpl<Req: 'static, Resp: 'static> {
     desc: ArcOrStatic<MethodDescriptor<Req, Resp>>,
-    method_handler: Box<MethodHandler<Req, Resp> + Sync + Send>,
+    method_handler: Box<dyn MethodHandler<Req, Resp> + Sync + Send>,
 }
 
 impl<Req, Resp> MethodHandlerDispatchUntyped for MethodHandlerDispatchImpl<Req, Resp>
@@ -370,7 +370,7 @@ where
 
 pub struct ServerMethod {
     pub(crate) name: StringOrStatic,
-    pub(crate) dispatch: Box<MethodHandlerDispatchUntyped + Sync + Send>,
+    pub(crate) dispatch: Box<dyn MethodHandlerDispatchUntyped + Sync + Send>,
 }
 
 impl ServerMethod {

--- a/grpc/src/server/req_handler.rs
+++ b/grpc/src/server/req_handler.rs
@@ -115,7 +115,7 @@ impl<H: ServerRequestStreamHandlerUntyped> httpbis::ServerStreamHandler
 
 struct ServerRequestStreamHandlerHandler<M: 'static, H: ServerRequestStreamHandler<M>> {
     handler: H,
-    marshaller: ArcOrStatic<Marshaller<M>>,
+    marshaller: ArcOrStatic<dyn Marshaller<M>>,
 }
 
 impl<M, H: ServerRequestStreamHandler<M>> ServerRequestStreamHandlerUntyped
@@ -164,7 +164,7 @@ impl<'a> ServerRequestUntyped<'a> {
 
 pub struct ServerRequest<'a, M: 'static> {
     pub(crate) req: ServerRequestUntyped<'a>,
-    pub(crate) marshaller: ArcOrStatic<Marshaller<M>>,
+    pub(crate) marshaller: ArcOrStatic<dyn Marshaller<M>>,
 }
 
 impl<'a, M: Send + 'static> ServerRequest<'a, M> {


### PR DESCRIPTION
Fixed warning about trait objects without explicit `dyn`.