### PR TITLE
Update clippy allow due to depreciation

### DIFF
--- a/grpc-compiler/src/codegen.rs
+++ b/grpc-compiler/src/codegen.rs
@@ -42,7 +42,7 @@ impl<'a> CodeWriter<'a> {
         self.write_line("");
         self.comment("https://github.com/Manishearth/rust-clippy/issues/702");
         self.write_line("#![allow(unknown_lints)]");
-        self.write_line("#![allow(clippy)]");
+        self.write_line("#![allow(clippy::all)]");
         self.write_line("");
         self.write_line("#![cfg_attr(rustfmt, rustfmt_skip)]");
         self.write_line("");


### PR DESCRIPTION
Clippy complains that `#![allow(clippy)]` is depreciated. This change changes it to `#![allow(clippy::all)]`. 

Closes:
#178 