### PR TITLE
add content-type in headers_500 function

### DIFF
--- a/grpc/src/proto/headers.rs
+++ b/grpc/src/proto/headers.rs
@@ -10,6 +10,7 @@ pub(crate) static HEADER_GRPC_MESSAGE: &'static str = "grpc-message";
 pub(crate) fn headers_500(grpc_status: GrpcStatus, message: String) -> Headers {
     Headers::from_vec(vec![
         Header::new(":status", "500"),
+        Header::new("content-type", "application/grpc"),
         Header::new(HEADER_GRPC_STATUS, format!("{}", grpc_status as i32)),
         Header::new(HEADER_GRPC_MESSAGE, message),
     ])


### PR DESCRIPTION
headers_500 function misses content-type field when sending error response, which results in client failed to read the grpc status.

closes #187